### PR TITLE
fix: 5問終了時に韻ランク表示を追加 (#6)

### DIFF
--- a/src/features/quiz/domain/logic/__tests__/scoring.test.ts
+++ b/src/features/quiz/domain/logic/__tests__/scoring.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { calculateScore } from "../scoring"
+import { calculateScore, getRhymeRank } from "../scoring"
 
 describe("calculateScore", () => {
 	it("全問正解のとき correct=5, percentage=100 を返す", () => {
@@ -38,5 +38,22 @@ describe("calculateScore", () => {
 		expect(score.correct).toBe(0)
 		expect(score.total).toBe(0)
 		expect(score.percentage).toBe(0)
+	})
+})
+
+
+describe("getRhymeRank", () => {
+	it("0〜5問正解に対応した称号を返す", () => {
+		expect(getRhymeRank(0)).toBe("韻の素人")
+		expect(getRhymeRank(1)).toBe("韻の見習い")
+		expect(getRhymeRank(2)).toBe("韻の黒帯")
+		expect(getRhymeRank(3)).toBe("韻のプロ")
+		expect(getRhymeRank(4)).toBe("韻の皇帝")
+		expect(getRhymeRank(5)).toBe("韻の神")
+	})
+
+	it("範囲外の正解数は0〜5に丸める", () => {
+		expect(getRhymeRank(-1)).toBe("韻の素人")
+		expect(getRhymeRank(10)).toBe("韻の神")
 	})
 })

--- a/src/features/quiz/domain/logic/scoring.ts
+++ b/src/features/quiz/domain/logic/scoring.ts
@@ -4,6 +4,15 @@ export interface ScoreResult {
 	percentage: number
 }
 
+const RHYME_RANKS = [
+	"韻の素人",
+	"韻の見習い",
+	"韻の黒帯",
+	"韻のプロ",
+	"韻の皇帝",
+	"韻の神",
+] as const
+
 export function calculateScore(
 	results: { isCorrect: boolean }[],
 ): ScoreResult {
@@ -11,4 +20,9 @@ export function calculateScore(
 	const total = results.length
 	const percentage = total === 0 ? 0 : Math.round((correct / total) * 100)
 	return { correct, total, percentage }
+}
+
+export function getRhymeRank(correctCount: number): string {
+	const safeCorrectCount = Math.max(0, Math.min(5, correctCount))
+	return RHYME_RANKS[safeCorrectCount]
 }

--- a/src/features/quiz/presentation/QuizPage.tsx
+++ b/src/features/quiz/presentation/QuizPage.tsx
@@ -1,7 +1,7 @@
 import { Button } from "#/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "#/components/ui/card"
 
-import { calculateScore } from "../domain/logic/scoring"
+import { calculateScore, getRhymeRank } from "../domain/logic/scoring"
 import { useCurrentQuestion, useQuizStore } from "./hooks/useQuiz"
 import { QuizCard } from "./parts/QuizCard"
 import { ResultDisplay } from "./parts/ResultDisplay"
@@ -19,6 +19,7 @@ export function QuizPage() {
 
 	if (phase === "finished") {
 		const score = calculateScore(results)
+		const rank = score.total >= 5 ? getRhymeRank(score.correct) : null
 		return (
 			<div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
 				<Card className="w-full max-w-lg">
@@ -47,6 +48,7 @@ export function QuizPage() {
 										? "まあまあです！"
 										: "もう一度挑戦してみよう！"}
 						</div>
+						{rank && <div className="text-2xl font-bold text-purple-700">{rank}</div>}
 						<Button className="w-full" onClick={reset}>
 							もう一度プレイする
 						</Button>


### PR DESCRIPTION
### Motivation
- クイズ5問終了時の結果画面に、正解数に応じた称号（韻ランク）を表示する機能を実装するため。

### Description
- `src/features/quiz/domain/logic/scoring.ts` に `RHYME_RANKS` と `getRhymeRank(correctCount)` を追加して正解数(0〜5)を称号にマッピングするようにしました。 
- `src/features/quiz/presentation/QuizPage.tsx` を更新して、`score.total >= 5` の場合に `getRhymeRank(score.correct)` を取得して結果画面に表示するようにしました。 
- `src/features/quiz/domain/logic/__tests__/scoring.test.ts` に `getRhymeRank` の正常系と範囲外入力（丸め込み）のユニットテストを追加しました。

### Testing
- `pnpm test` を実行して既存のテストと追加したテストを含むすべてのテストが成功しました（`21 tests passed`）。
- `pnpm dev` で開発サーバーは起動しましたが、環境により Playwright で `http://localhost:3000/quiz` へ接続すると `ERR_EMPTY_RESPONSE` となりスクリーンショットは取得できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ef6f24360832f841704cfc164f5e7)