### PR TITLE
feat(quiz): implement difficulty scaling by question number

### DIFF
--- a/src/features/quiz/infrastructure/data/quizData.ts
+++ b/src/features/quiz/infrastructure/data/quizData.ts
@@ -1,6 +1,7 @@
 import type { QuizFull } from "../../domain/entities/quiz"
 
 export const quizzes: QuizFull[] = [
+	// Q1: 2文字・2択（初級）
 	{
 		id: "q1",
 		questionWord: "とら",
@@ -10,10 +11,9 @@ export const quizzes: QuizFull[] = [
 		choices: [
 			{ id: "q1-c1", text: "おか", vowels: "おあ", isCorrect: true },
 			{ id: "q1-c2", text: "ぶた", vowels: "うあ", isCorrect: false },
-			{ id: "q1-c3", text: "ふぐ", vowels: "うう", isCorrect: false },
-			{ id: "q1-c4", text: "さる", vowels: "あう", isCorrect: false },
 		],
 	},
+	// Q2: 3文字・3択
 	{
 		id: "q2",
 		questionWord: "くるま",
@@ -25,49 +25,66 @@ export const quizzes: QuizFull[] = [
 			{ id: "q2-c1", text: "つくば", vowels: "ううあ", isCorrect: true },
 			{ id: "q2-c2", text: "さくら", vowels: "あうあ", isCorrect: false },
 			{ id: "q2-c3", text: "みどり", vowels: "いおい", isCorrect: false },
-			{ id: "q2-c4", text: "かばん", vowels: "ああん", isCorrect: false },
 		],
 	},
+	// Q3: 4文字・4択
 	{
 		id: "q3",
-		questionWord: "ひかり",
-		questionVowels: "いあい",
-		imageKey: "hikari",
+		questionWord: "うみかぜ",
+		questionVowels: "ういあえ",
+		imageKey: "umikaze",
 		explanation:
-			"「ひかり」の母音は「いあい」。同じ母音パターンの「みなみ」が正解。",
+			"「うみかぜ」の母音は「ういあえ」。同じ母音パターンの「つきかげ」が正解。",
 		choices: [
-			{ id: "q3-c1", text: "みなみ", vowels: "いあい", isCorrect: true },
-			{ id: "q3-c2", text: "あさひ", vowels: "ああい", isCorrect: false },
-			{ id: "q3-c3", text: "いのち", vowels: "いおい", isCorrect: false },
-			{ id: "q3-c4", text: "きもち", vowels: "いおい", isCorrect: false },
+			{ id: "q3-c1", text: "つきかげ", vowels: "ういあえ", isCorrect: true },
+			{ id: "q3-c2", text: "はなびら", vowels: "ああいあ", isCorrect: false },
+			{ id: "q3-c3", text: "ひまわり", vowels: "いああい", isCorrect: false },
+			{ id: "q3-c4", text: "すずらん", vowels: "ううあん", isCorrect: false },
 		],
 	},
+	// Q4: 6文字・8択
 	{
 		id: "q4",
-		questionWord: "なみだ",
-		questionVowels: "あいあ",
-		imageKey: "namida",
+		questionWord: "むかしばなし",
+		questionVowels: "うあいああい",
+		imageKey: "mukashibanashi",
 		explanation:
-			"「なみだ」の母音は「あいあ」。同じ母音パターンの「かみな（り）」が正解。",
+			"「むかしばなし」の母音は「うあいああい」。同じ母音パターンの「つかいはたし」が正解。",
 		choices: [
-			{ id: "q4-c1", text: "かみな（り）", vowels: "あいあ", isCorrect: true },
-			{ id: "q4-c2", text: "おもて", vowels: "おおえ", isCorrect: false },
-			{ id: "q4-c3", text: "ゆめじ", vowels: "うえい", isCorrect: false },
-			{ id: "q4-c4", text: "はなび", vowels: "あああ", isCorrect: false },
+			{ id: "q4-c1", text: "つかいはたし", vowels: "うあいああい", isCorrect: true },
+			{ id: "q4-c2", text: "まつりばやし", vowels: "あういああい", isCorrect: false },
+			{ id: "q4-c3", text: "なつのおもい", vowels: "あうおおおい", isCorrect: false },
+			{ id: "q4-c4", text: "そらとぶかぜ", vowels: "おあおうあえ", isCorrect: false },
+			{ id: "q4-c5", text: "ゆうひのかぜ", vowels: "うういおあえ", isCorrect: false },
+			{ id: "q4-c6", text: "きのこのかさ", vowels: "いおおおああ", isCorrect: false },
+			{ id: "q4-c7", text: "おにのぱんつ", vowels: "おいおあんう", isCorrect: false },
+			{ id: "q4-c8", text: "たのしいうた", vowels: "あおいいうあ", isCorrect: false },
 		],
 	},
+	// Q5: 10文字・15択（上級）
 	{
 		id: "q5",
-		questionWord: "そら",
-		questionVowels: "おあ",
-		imageKey: "sora",
+		questionWord: "むかしむかしのはなし",
+		questionVowels: "うあいうあいおああい",
+		imageKey: "mukashimukashinohanashi",
 		explanation:
-			"「そら」の母音は「おあ」。同じ母音パターンの「こま」が正解。",
+			"「むかしむかしのはなし」の母音は「うあいうあいおああい」。同じ母音パターンの「ふかいふかいのはなし」が正解。",
 		choices: [
-			{ id: "q5-c1", text: "こま", vowels: "おあ", isCorrect: true },
-			{ id: "q5-c2", text: "もり", vowels: "おい", isCorrect: false },
-			{ id: "q5-c3", text: "かぜ", vowels: "あえ", isCorrect: false },
-			{ id: "q5-c4", text: "つき", vowels: "うい", isCorrect: false },
+			{ id: "q5-c1", text: "ふかいふかいのはなし", vowels: "うあいうあいおああい", isCorrect: true },
+			{ id: "q5-c2", text: "いつもそばにいるよね", vowels: "いうおおあいいうおえ", isCorrect: false },
+			{ id: "q5-c3", text: "このよるをこえていけ", vowels: "おおおうおおええいえ", isCorrect: false },
+			{ id: "q5-c4", text: "あかいめがさすほどに", vowels: "ああいえああうおおい", isCorrect: false },
+			{ id: "q5-c5", text: "さいごまでそこにいろ", vowels: "あいおあえおおいいお", isCorrect: false },
+			{ id: "q5-c6", text: "はなれてもそばにいる", vowels: "ああええおおあいいう", isCorrect: false },
+			{ id: "q5-c7", text: "うたのそらをとびかけ", vowels: "うあおおあおおいあえ", isCorrect: false },
+			{ id: "q5-c8", text: "きみのこえがきこえる", vowels: "いいおおえあいおえう", isCorrect: false },
+			{ id: "q5-c9", text: "なつのひかりをあびて", vowels: "あうおいあいおあいえ", isCorrect: false },
+			{ id: "q5-c10", text: "ゆめのなかでふわふわ", vowels: "うえおああえうあうあ", isCorrect: false },
+			{ id: "q5-c11", text: "そらのかなたのほしよ", vowels: "おあおあああおおいお", isCorrect: false },
+			{ id: "q5-c12", text: "まいにちがんばるきみ", vowels: "あいいいあんあういい", isCorrect: false },
+			{ id: "q5-c13", text: "ぼくらのそらをとべよ", vowels: "おうあおおあおおえお", isCorrect: false },
+			{ id: "q5-c14", text: "うみへとびこんだなつ", vowels: "ういえおいおんああう", isCorrect: false },
+			{ id: "q5-c15", text: "おれたちはとんでいく", vowels: "おえあいあおんえいう", isCorrect: false },
 		],
 	},
 ]


### PR DESCRIPTION
## Summary
- 問題番号が進むごとに難易度が上がるよう問題データを更新
- 変更ファイル: `src/features/quiz/infrastructure/data/quizData.ts` のみ

| 問題 | 文字数 | 選択肢数 | 問題語 |
|------|--------|----------|--------|
| Q1 | 2文字 | 2択 | とら |
| Q2 | 3文字 | 3択 | くるま |
| Q3 | 4文字 | 4択 | うみかぜ |
| Q4 | 6文字 | 8択 | むかしばなし |
| Q5 | 10文字 | 15択 | むかしむかしのはなし |

## Test plan
- [ ] 各問題の母音パターンが正しいことを確認
- [ ] Q1〜Q5 すべてプレイして正解・不正解が正しく判定されることを確認
- [ ] Q5 の15択が画面に正しく表示されることを確認

closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)