### PR TITLE
fix(quiz): shuffle choices order randomly per question load

### DIFF
--- a/src/features/quiz/application/services/quizService.ts
+++ b/src/features/quiz/application/services/quizService.ts
@@ -19,11 +19,15 @@ export async function getQuestionByIndex(
 	const quiz = allQuizzes[index]
 	if (!quiz) return null
 
+	const shuffledChoices = quiz.choices
+		.map((c) => ({ id: c.id, text: c.text }))
+		.sort(() => Math.random() - 0.5)
+
 	return {
 		id: quiz.id,
 		questionWord: quiz.questionWord,
 		imageKey: quiz.imageKey,
-		choices: quiz.choices.map((c) => ({ id: c.id, text: c.text })),
+		choices: shuffledChoices,
 		total: allQuizzes.length,
 		index,
 	}


### PR DESCRIPTION
## Summary
- 問題ロード時に選択肢をランダムにシャッフルして返すよう修正
- `getQuestionByIndex` 内で `.sort(() => Math.random() - 0.5)` を適用
- 正解が常に1番上に表示される問題を解消

## 変更ファイル
- `src/features/quiz/application/services/quizService.ts`

## Test plan
- [ ] 同じ問題をリロードするたびに選択肢の順番が変わることを確認
- [ ] 正解・不正解の判定が引き続き正しく動作することを確認

closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)