### PR TITLE
Fix #15: 5問終了時のRESULTをピンク背景の中央に配置

### DIFF
--- a/src/features/quiz/presentation/parts/FinalResult.tsx
+++ b/src/features/quiz/presentation/parts/FinalResult.tsx
@@ -27,9 +27,9 @@ export function FinalResult({ score, rank, onReset }: FinalResultProps) {
 	}
 
 	return (
-		<div className="min-h-[80vh] flex items-center justify-center p-4">
+		<div className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-b from-pink-50 via-purple-50 to-pink-100">
 			<Card className="w-full max-w-lg overflow-hidden border-2 border-purple-100 shadow-2xl animate-in fade-in zoom-in duration-500">
-				<CardHeader className="bg-gradient-to-r from-purple-100 via-pink-50 to-purple-100 border-b border-purple-100">
+				<CardHeader className="min-h-28 flex items-center justify-center bg-gradient-to-r from-purple-100 via-pink-50 to-purple-100 border-b border-purple-100">
 					<CardTitle className="text-center text-3xl font-extrabold bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-pink-600">
 						RESULT
 					</CardTitle>


### PR DESCRIPTION
### Motivation
- FinalResult がピンク背景の上寄せになっていたため、5問終了時の結果カードを背景中央に表示するよう調整しました。

### Description
- `src/features/quiz/presentation/parts/FinalResult.tsx` のルートコンテナを `min-h-[80vh]` から `min-h-screen` に変更し、ピンク系の背景グラデーションを追加しました。
- `CardHeader` に `min-h-28 flex items-center justify-center` を追加して `RESULT` 見出しを中央寄せにしました。

### Testing
- 実行した自動テスト: `pnpm -s test` — 成功（21 件のテストがすべてパス）。
- 実行した自動チェック: `pnpm -s check` — 既存の lint/format 指摘により失敗（今回の変更とは無関係な既存ファイルの診断が原因）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f065a9618832fac0366547f848249)