### PR TITLE
fix(quiz): center final result card in pink background

### DIFF
--- a/src/features/quiz/presentation/parts/FinalResult.tsx
+++ b/src/features/quiz/presentation/parts/FinalResult.tsx
@@ -27,7 +27,7 @@ export function FinalResult({ score, rank, onReset }: FinalResultProps) {
 	}
 
 	return (
-		<div className="min-h-[80vh] flex items-center justify-center p-4">
+		<div className="min-h-screen bg-pink-50 flex items-center justify-center p-4">
 			<Card className="w-full max-w-lg overflow-hidden border-2 border-purple-100 shadow-2xl animate-in fade-in zoom-in duration-500">
 				<CardHeader className="bg-gradient-to-r from-purple-100 via-pink-50 to-purple-100 border-b border-purple-100">
 					<CardTitle className="text-center text-3xl font-extrabold bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-pink-600">


### PR DESCRIPTION
## Summary
- 5問終了時の RESULT カードをピンク背景の中央に表示するよう修正

## 原因
- `min-h-[80vh]` はビューポートの80%しか確保しないため、Header の高さが考慮されずカードが上寄りになっていた
- 背景色も未指定だったため「ピンク背景の中央」にならなかった

## 修正
- `min-h-[80vh]` → `min-h-screen` に変更し、フル画面で中央揃えを保証
- `bg-pink-50` を追加してピンク背景を明示

## 変更ファイル
- `src/features/quiz/presentation/parts/FinalResult.tsx`（1行変更）

## Test plan
- [ ] 5問クリア後に RESULT カードがピンク背景の中央に表示されることを確認

closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)