### PR TITLE
選択肢テキストクリックでも選択できるように対応

### DIFF
--- a/src/features/quiz/presentation/parts/ChoiceList.tsx
+++ b/src/features/quiz/presentation/parts/ChoiceList.tsx
@@ -17,6 +17,7 @@ export function ChoiceList({ choices }: ChoiceListProps) {
 				<div
 					key={choice.id}
 					className="flex items-center gap-3 p-3 rounded-lg border hover:bg-gray-50 cursor-pointer transition-colors"
+					onClick={() => toggleChoice(choice.id)}
 				>
 					<Checkbox
 						id={choice.id}


### PR DESCRIPTION
### Motivation
- Issue #20 に対応し、選択肢のテキストや行の余白をクリックしても選択が切り替わるようにして UX を向上させるため。 

### Description
- `src/features/quiz/presentation/parts/ChoiceList.tsx` の各選択肢行コンテナに `onClick={() => toggleChoice(choice.id)}` を追加して行全体で選択をトグルできるようにし、既存の `Checkbox` の `onCheckedChange` と `onClick={(e) => e.stopPropagation()}` はそのまま維持しています。 

### Testing
- 自動テストを `pnpm test` で実行し、全テスト（21 件）が通過しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f0efb77f8832fb424f755a4edb178)