### PR TITLE
feat(ui): add Magic UI components for modern look #19

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,12 +2,14 @@ import { Link } from "@tanstack/react-router";
 import { Home, Menu, Music, X } from "lucide-react";
 import { useState } from "react";
 
+import { AnimatedGradientText } from "#/components/magicui/animated-gradient-text";
+
 export default function Header() {
 	const [isOpen, setIsOpen] = useState(false);
 
 	return (
 		<>
-			<header className="p-4 flex items-center bg-gray-800 text-white shadow-lg">
+			<header className="p-4 flex items-center bg-gray-900 text-white shadow-lg border-b border-white/10">
 				<button
 					type="button"
 					onClick={() => setIsOpen(true)}
@@ -16,8 +18,16 @@ export default function Header() {
 				>
 					<Menu size={24} />
 				</button>
-				<h1 className="ml-4 text-2xl font-semibold">
-					<Link to="/">Rhyme Quiz</Link>
+				<h1 className="ml-4 text-2xl font-bold">
+					<Link to="/">
+						<AnimatedGradientText
+							colorFrom="#a855f7"
+							colorTo="#ec4899"
+							speed={1.2}
+						>
+							Rhyme Quiz
+						</AnimatedGradientText>
+					</Link>
 				</h1>
 			</header>
 
@@ -45,7 +55,7 @@ export default function Header() {
 						className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-800 transition-colors mb-2"
 						activeProps={{
 							className:
-								"flex items-center gap-3 p-3 rounded-lg bg-cyan-600 hover:bg-cyan-700 transition-colors mb-2",
+								"flex items-center gap-3 p-3 rounded-lg bg-purple-700 hover:bg-purple-800 transition-colors mb-2",
 						}}
 					>
 						<Home size={20} />
@@ -58,7 +68,7 @@ export default function Header() {
 						className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-800 transition-colors mb-2"
 						activeProps={{
 							className:
-								"flex items-center gap-3 p-3 rounded-lg bg-cyan-600 hover:bg-cyan-700 transition-colors mb-2",
+								"flex items-center gap-3 p-3 rounded-lg bg-purple-700 hover:bg-purple-800 transition-colors mb-2",
 						}}
 					>
 						<Music size={20} />

--- a/src/components/magicui/animated-gradient-text.tsx
+++ b/src/components/magicui/animated-gradient-text.tsx
@@ -1,0 +1,38 @@
+import type { ComponentPropsWithoutRef, CSSProperties } from "react";
+
+import { cn } from "#/lib/utils";
+
+export interface AnimatedGradientTextProps
+	extends ComponentPropsWithoutRef<"span"> {
+	speed?: number;
+	colorFrom?: string;
+	colorTo?: string;
+}
+
+export function AnimatedGradientText({
+	children,
+	className,
+	speed = 1,
+	colorFrom = "#a855f7",
+	colorTo = "#ec4899",
+	...props
+}: AnimatedGradientTextProps) {
+	return (
+		<span
+			style={
+				{
+					"--bg-size": `${speed * 300}%`,
+					"--color-from": colorFrom,
+					"--color-to": colorTo,
+				} as CSSProperties
+			}
+			className={cn(
+				"animate-gradient inline bg-gradient-to-r from-[var(--color-from)] via-[var(--color-to)] to-[var(--color-from)] bg-[length:var(--bg-size)_100%] bg-clip-text text-transparent",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</span>
+	);
+}

--- a/src/components/magicui/animated-shiny-text.tsx
+++ b/src/components/magicui/animated-shiny-text.tsx
@@ -1,0 +1,33 @@
+import type { ComponentPropsWithoutRef, CSSProperties, FC } from "react";
+
+import { cn } from "#/lib/utils";
+
+export interface AnimatedShinyTextProps
+	extends ComponentPropsWithoutRef<"span"> {
+	shimmerWidth?: number;
+}
+
+export const AnimatedShinyText: FC<AnimatedShinyTextProps> = ({
+	children,
+	className,
+	shimmerWidth = 100,
+	...props
+}) => {
+	return (
+		<span
+			style={
+				{
+					"--shiny-width": `${shimmerWidth}px`,
+				} as CSSProperties
+			}
+			className={cn(
+				"animate-shiny-text bg-clip-text [background-size:var(--shiny-width)_100%] [background-position:0_0] bg-no-repeat [transition:background-position_1s_cubic-bezier(.6,.6,0,1)_infinite]",
+				"bg-gradient-to-r from-transparent via-black/80 via-50% to-transparent",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</span>
+	);
+};

--- a/src/components/magicui/shimmer-button.tsx
+++ b/src/components/magicui/shimmer-button.tsx
@@ -1,0 +1,83 @@
+import React, {
+	type ComponentPropsWithoutRef,
+	type CSSProperties,
+} from "react";
+
+import { cn } from "#/lib/utils";
+
+export interface ShimmerButtonProps extends ComponentPropsWithoutRef<"button"> {
+	shimmerColor?: string;
+	shimmerSize?: string;
+	borderRadius?: string;
+	shimmerDuration?: string;
+	background?: string;
+}
+
+export const ShimmerButton = React.forwardRef<
+	HTMLButtonElement,
+	ShimmerButtonProps
+>(
+	(
+		{
+			shimmerColor = "#ffffff",
+			shimmerSize = "0.05em",
+			shimmerDuration = "3s",
+			borderRadius = "100px",
+			background = "rgba(0, 0, 0, 1)",
+			className,
+			children,
+			...props
+		},
+		ref,
+	) => {
+		return (
+			<button
+				style={
+					{
+						"--spread": "90deg",
+						"--shimmer-color": shimmerColor,
+						"--radius": borderRadius,
+						"--speed": shimmerDuration,
+						"--cut": shimmerSize,
+						"--bg": background,
+					} as CSSProperties
+				}
+				className={cn(
+					"group relative z-0 flex cursor-pointer items-center justify-center overflow-hidden [border-radius:var(--radius)] border border-white/10 px-6 py-3 whitespace-nowrap text-white [background:var(--bg)]",
+					"transform-gpu transition-transform duration-300 ease-in-out active:translate-y-px",
+					className,
+				)}
+				ref={ref}
+				{...props}
+			>
+				<div
+					className={cn(
+						"-z-30 blur-[2px]",
+						"[container-type:size] absolute inset-0 overflow-visible",
+					)}
+				>
+					<div className="animate-shimmer-slide absolute inset-0 [aspect-ratio:1] h-[100cqh] [border-radius:0] [mask:none]">
+						<div className="animate-spin-around absolute -inset-full w-auto [translate:0_0] rotate-0 [background:conic-gradient(from_calc(270deg-(var(--spread)*0.5)),transparent_0,var(--shimmer-color)_var(--spread),transparent_var(--spread))]" />
+					</div>
+				</div>
+				{children}
+				<div
+					className={cn(
+						"absolute inset-0 size-full",
+						"rounded-2xl px-4 py-1.5 text-sm font-medium shadow-[inset_0_-8px_10px_#ffffff1f]",
+						"transform-gpu transition-all duration-300 ease-in-out",
+						"group-hover:shadow-[inset_0_-6px_10px_#ffffff3f]",
+						"group-active:shadow-[inset_0_-10px_10px_#ffffff3f]",
+					)}
+				/>
+				<div
+					className={cn(
+						"absolute [inset:var(--cut)] -z-20 [border-radius:var(--radius)] [background:var(--bg)]",
+					)}
+				/>
+			</button>
+		);
+	},
+);
+
+ShimmerButton.displayName = "ShimmerButton";

--- a/src/components/magicui/shine-border.tsx
+++ b/src/components/magicui/shine-border.tsx
@@ -1,0 +1,45 @@
+import type React from "react";
+
+import { cn } from "#/lib/utils";
+
+interface ShineBorderProps extends React.HTMLAttributes<HTMLDivElement> {
+	borderWidth?: number;
+	duration?: number;
+	shineColor?: string | string[];
+}
+
+export function ShineBorder({
+	borderWidth = 1,
+	duration = 14,
+	shineColor = "#000000",
+	className,
+	style,
+	...props
+}: ShineBorderProps) {
+	return (
+		<div
+			style={
+				{
+					"--border-width": `${borderWidth}px`,
+					"--duration": `${duration}s`,
+					backgroundImage: `radial-gradient(transparent,transparent, ${
+						Array.isArray(shineColor) ? shineColor.join(",") : shineColor
+					},transparent,transparent)`,
+					backgroundSize: "300% 300%",
+					mask: "linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
+					WebkitMask:
+						"linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
+					WebkitMaskComposite: "xor",
+					maskComposite: "exclude",
+					padding: "var(--border-width)",
+					...style,
+				} as React.CSSProperties
+			}
+			className={cn(
+				"motion-safe:animate-shine pointer-events-none absolute inset-0 size-full rounded-[inherit] will-change-[background-position]",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}

--- a/src/features/quiz/presentation/parts/FinalResult.tsx
+++ b/src/features/quiz/presentation/parts/FinalResult.tsx
@@ -1,5 +1,6 @@
-import { Button } from "#/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "#/components/ui/card";
+import { AnimatedShinyText } from "#/components/magicui/animated-shiny-text";
+import { ShimmerButton } from "#/components/magicui/shimmer-button";
+import { Card, CardContent, CardHeader } from "#/components/ui/card";
 import type { ScoreResult } from "../../domain/logic/scoring";
 
 interface FinalResultProps {
@@ -27,12 +28,17 @@ export function FinalResult({ score, rank, onReset }: FinalResultProps) {
 	};
 
 	return (
-		<div className="min-h-[80vh] flex items-center justify-center p-4">
+		<div className="min-h-screen bg-pink-50 flex items-center justify-center p-4">
 			<Card className="w-full max-w-lg overflow-hidden border-2 border-purple-100 shadow-2xl animate-in fade-in zoom-in duration-500">
-				<CardHeader className="bg-gradient-to-r from-purple-100 via-pink-50 to-purple-100 border-b border-purple-100">
-					<CardTitle className="text-center text-3xl font-extrabold bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-pink-600">
-						RESULT
-					</CardTitle>
+				<CardHeader className="bg-gradient-to-r from-purple-100 via-pink-50 to-purple-100 border-b border-purple-100 py-6">
+					<div className="text-center">
+						<AnimatedShinyText
+							shimmerWidth={160}
+							className="text-3xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-purple-600 to-pink-600 via-purple-500"
+						>
+							RESULT
+						</AnimatedShinyText>
+					</div>
 				</CardHeader>
 				<CardContent className="space-y-8 p-8 text-center relative">
 					{rank === "韻の神" && (
@@ -94,13 +100,17 @@ export function FinalResult({ score, rank, onReset }: FinalResultProps) {
 									: "リベンジ待ってるぜ！"}
 					</div>
 
-					<Button
-						size="lg"
-						className="w-full h-16 text-xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 transition-all shadow-lg hover:shadow-purple-200/50 active:scale-[0.98]"
+					<ShimmerButton
+						type="button"
+						className="w-full h-16 text-xl font-bold"
+						background="linear-gradient(135deg, #7c3aed, #db2777)"
+						borderRadius="0.5rem"
+						shimmerColor="#ffffff"
+						shimmerDuration="2.5s"
 						onClick={onReset}
 					>
 						もう一度挑戦する
-					</Button>
+					</ShimmerButton>
 				</CardContent>
 			</Card>
 			<style>{`

--- a/src/features/quiz/presentation/parts/QuizCard.tsx
+++ b/src/features/quiz/presentation/parts/QuizCard.tsx
@@ -1,6 +1,7 @@
 import { ImageIcon } from "lucide-react";
 
-import { Button } from "#/components/ui/button";
+import { ShimmerButton } from "#/components/magicui/shimmer-button";
+import { ShineBorder } from "#/components/magicui/shine-border";
 import { Card, CardContent, CardHeader, CardTitle } from "#/components/ui/card";
 
 import type { QuizQuestion } from "../../contracts/quiz";
@@ -23,29 +24,43 @@ export function QuizCard({ question }: QuizCardProps) {
 	};
 
 	return (
-		<Card className="w-full">
-			<CardHeader>
-				<CardTitle className="text-center text-xl">
-					「{question.questionWord}」で踏める韻は？
-				</CardTitle>
-			</CardHeader>
-			<CardContent className="space-y-6">
-				<div className="flex justify-center">
-					<div className="w-40 h-40 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300">
-						<ImageIcon className="w-12 h-12 text-gray-400" />
+		<div className="relative">
+			<ShineBorder
+				borderWidth={2}
+				duration={10}
+				shineColor={["#a855f7", "#ec4899", "#6366f1"]}
+			/>
+			<Card className="w-full">
+				<CardHeader>
+					<CardTitle className="text-center text-xl">
+						「{question.questionWord}」で踏める韻は？
+					</CardTitle>
+				</CardHeader>
+				<CardContent className="space-y-6">
+					<div className="flex justify-center">
+						<div className="w-40 h-40 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300">
+							<ImageIcon className="w-12 h-12 text-gray-400" />
+						</div>
 					</div>
-				</div>
 
-				<ChoiceList choices={question.choices} />
+					<ChoiceList choices={question.choices} />
 
-				<Button
-					className="w-full"
-					onClick={handleSubmit}
-					disabled={selectedChoiceIds.length === 0 || submitMutation.isPending}
-				>
-					{submitMutation.isPending ? "判定中..." : "解答する"}
-				</Button>
-			</CardContent>
-		</Card>
+					<ShimmerButton
+						type="button"
+						className="w-full h-12 text-base font-bold"
+						background="linear-gradient(135deg, #7c3aed, #db2777)"
+						borderRadius="0.5rem"
+						shimmerColor="#ffffff"
+						shimmerDuration="2.5s"
+						onClick={handleSubmit}
+						disabled={
+							selectedChoiceIds.length === 0 || submitMutation.isPending
+						}
+					>
+						{submitMutation.isPending ? "判定中..." : "解答する"}
+					</ShimmerButton>
+				</CardContent>
+			</Card>
+		</div>
 	);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -136,3 +136,46 @@ code {
     @apply bg-background text-foreground;
   }
 }
+
+/* ─── Magic UI animations ─── */
+@theme inline {
+  --animate-shimmer-slide: shimmer-slide var(--speed, 3s) ease-in-out infinite alternate;
+  --animate-spin-around: spin-around calc(var(--speed, 3s) * 2) infinite linear;
+  --animate-shiny-text: shiny-text 8s infinite;
+  --animate-shine: shine 14s linear infinite;
+  --animate-gradient: gradient 8s linear infinite;
+}
+
+@keyframes shimmer-slide {
+  to {
+    transform: translate(calc(100cqw - 100%), 0);
+  }
+}
+
+@keyframes spin-around {
+  0% { transform: translateZ(0) rotate(0); }
+  15%, 35% { transform: translateZ(0) rotate(90deg); }
+  65%, 85% { transform: translateZ(0) rotate(270deg); }
+  100% { transform: translateZ(0) rotate(360deg); }
+}
+
+@keyframes shiny-text {
+  0%, 90%, 100% {
+    background-position: calc(-100% - var(--shiny-width, 100px)) 0;
+  }
+  30%, 60% {
+    background-position: calc(100% + var(--shiny-width, 100px)) 0;
+  }
+}
+
+@keyframes shine {
+  0% { background-position: 0% 0%; }
+  50% { background-position: 100% 100%; }
+  100% { background-position: 0% 0%; }
+}
+
+@keyframes gradient {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}


### PR DESCRIPTION
## Summary
- Magic UI の ShimmerButton・ShineBorder・AnimatedGradientText・AnimatedShinyText コンポーネントを追加
- Header の「Rhyme Quiz」タイトルにアニメーショングラデーションを適用
- QuizCard に ShineBorder（虹色の輝くボーダー）と ShimmerButton（解答ボタン）を適用
- FinalResult の「RESULT」テキストにシャイニーアニメーション、リセットボタンを ShimmerButton に変更
- styles.css に必要な @keyframes と Tailwind CSS 4 の @theme 定義を追加

## Test plan
- [ ] pnpm dev でエラー・警告が出ないことを確認
- [ ] Header の「Rhyme Quiz」文字にグラデーションアニメーションが表示される
- [ ] QuizCard の外枠に虹色のシャインボーダーが表示される
- [ ] 「解答する」ボタンにシマーエフェクトが表示される
- [ ] FinalResult の「RESULT」文字にシャイニーエフェクトが表示される
- [ ] 「もう一度挑戦する」ボタンにシマーエフェクトが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)