### PR TITLE
feat(quiz): show video on Q2 with swappable media provider #33

### DIFF
--- a/src/features/quiz/application/services/quizService.ts
+++ b/src/features/quiz/application/services/quizService.ts
@@ -1,4 +1,5 @@
 import type { QuizResult } from "../../domain/entities/quiz"
+import { resolveVideoUrl } from "../../infrastructure/media/mediaResolver"
 import { judgeAnswer } from "../../domain/logic/rhyme"
 import { getRepository } from "../../infrastructure/getRepository"
 
@@ -6,6 +7,7 @@ export interface QuestionForClient {
 	id: string
 	questionWord: string
 	imageKey: string
+	videoUrl?: string
 	choices: Array<{ id: string; text: string }>
 	total: number
 	index: number
@@ -27,6 +29,7 @@ export async function getQuestionByIndex(
 		id: quiz.id,
 		questionWord: quiz.questionWord,
 		imageKey: quiz.imageKey,
+		...(quiz.videoKey ? { videoUrl: resolveVideoUrl(quiz.videoKey) } : {}),
 		choices: shuffledChoices,
 		total: allQuizzes.length,
 		index,

--- a/src/features/quiz/contracts/quiz.ts
+++ b/src/features/quiz/contracts/quiz.ts
@@ -9,6 +9,7 @@ export const QuizQuestionSchema = z.object({
 	id: z.string(),
 	questionWord: z.string(),
 	imageKey: z.string(),
+	videoUrl: z.string().optional(),
 	choices: z.array(ChoiceSchema),
 	total: z.number(),
 	index: z.number(),

--- a/src/features/quiz/domain/entities/quiz.ts
+++ b/src/features/quiz/domain/entities/quiz.ts
@@ -10,6 +10,7 @@ export interface QuizFull {
 	questionWord: string;
 	questionVowels: string;
 	imageKey: string;
+	videoKey?: string;
 	explanation: string;
 	choices: ChoiceFull[];
 }

--- a/src/features/quiz/infrastructure/data/quizData.ts
+++ b/src/features/quiz/infrastructure/data/quizData.ts
@@ -13,18 +13,20 @@ export const quizzes: QuizFull[] = [
 			{ id: "q1-c2", text: "ぶた", vowels: "うあ", isCorrect: false },
 		],
 	},
-	// Q2: 3文字・3択（正解2つ）
+	// Q2: 3文字・4択（正解2つ・動画あり）
 	{
 		id: "q2",
-		questionWord: "くるま",
-		questionVowels: "ううあ",
-		imageKey: "kuruma",
+		questionWord: "あたま",
+		questionVowels: "あああ",
+		imageKey: "",
+		videoKey: "20260226_1254_01kjb86c8mf86rdf15zcrvc52b",
 		explanation:
-			"「くるま」の母音は「ううあ」。同じ母音パターンの「つくば」「くつわ」が正解。",
+			"「あたま」の母音は「あああ」。同じ母音パターンの「からだ」「ながら」が正解。",
 		choices: [
-			{ id: "q2-c1", text: "つくば", vowels: "ううあ", isCorrect: true },
-			{ id: "q2-c2", text: "くつわ", vowels: "ううあ", isCorrect: true },
-			{ id: "q2-c3", text: "みどり", vowels: "いおい", isCorrect: false },
+			{ id: "q2-c1", text: "からだ", vowels: "あああ", isCorrect: true },
+			{ id: "q2-c2", text: "ながら", vowels: "あああ", isCorrect: true },
+			{ id: "q2-c3", text: "つかい", vowels: "うあい", isCorrect: false },
+			{ id: "q2-c4", text: "にして", vowels: "いいえ", isCorrect: false },
 		],
 	},
 	// Q3: 4文字・4択（正解3つ）

--- a/src/features/quiz/infrastructure/media/mediaResolver.ts
+++ b/src/features/quiz/infrastructure/media/mediaResolver.ts
@@ -1,0 +1,18 @@
+export type VideoProvider = "local" | "cloudinary" | "bunny";
+
+function getVideoProvider(): VideoProvider {
+	return (process.env.VIDEO_PROVIDER as VideoProvider) ?? "local";
+}
+
+export function resolveVideoUrl(key: string): string {
+	const provider = getVideoProvider();
+	switch (provider) {
+		case "cloudinary":
+			return `https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/video/upload/${key}.mp4`;
+		case "bunny":
+			return `https://${process.env.BUNNY_HOSTNAME}/${key}.mp4`;
+		case "local":
+		default:
+			return `/video/${key}.mp4`;
+	}
+}

--- a/src/features/quiz/presentation/parts/QuizCard.tsx
+++ b/src/features/quiz/presentation/parts/QuizCard.tsx
@@ -37,11 +37,21 @@ export function QuizCard({ question }: QuizCardProps) {
 					</CardTitle>
 				</CardHeader>
 				<CardContent className="space-y-6">
-					<div className="flex justify-center">
-						<div className="w-40 h-40 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300">
-							<ImageIcon className="w-12 h-12 text-gray-400" />
+					{question.videoUrl ? (
+						<div className="flex justify-center">
+							<video
+								src={question.videoUrl}
+								controls
+								className="w-full max-w-sm rounded-lg"
+							/>
 						</div>
-					</div>
+					) : (
+						<div className="flex justify-center">
+							<div className="w-40 h-40 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300">
+								<ImageIcon className="w-12 h-12 text-gray-400" />
+							</div>
+						</div>
+					)}
 
 					<ChoiceList choices={question.choices} />
 


### PR DESCRIPTION
## Summary
- Q2の問題を「あたま」に変更し、動画（`public/video/20260226_1254_01kjb86c8mf86rdf15zcrvc52b.mp4`）を表示
- Q2の選択肢をからだ・ながら（正解）・つかい・にして（不正解）に変更
- 動画表示時は画像プレースホルダーを非表示
- 将来的にCloudinary/Bunny Streamへ切り替えられるよう `mediaResolver.ts` を新規作成

## アーキテクチャ
- `domain/entities/quiz.ts` — `QuizFull` に `videoKey?: string` を追加
- `infrastructure/media/mediaResolver.ts` (新規) — `VIDEO_PROVIDER` 環境変数で切り替え可能な URL リゾルバー
  - `local`（デフォルト）: `/video/${key}.mp4`
  - `cloudinary`: Cloudinary動画URL
  - `bunny`: Bunny StreamのURL
- `application/services/quizService.ts` — サーバー側でURLを解決して `videoUrl?` としてクライアントへ返す
- `contracts/quiz.ts` — `videoUrl: z.string().optional()` を追加
- `presentation/parts/QuizCard.tsx` — `videoUrl` があれば `<video>` タグ、なければ画像プレースホルダーを表示

## プロバイダー切り替え方法
`.env` に以下を設定するだけで切り替え可能:
```
VIDEO_PROVIDER=cloudinary  # or "bunny" or "local"
CLOUDINARY_CLOUD_NAME=xxx  # cloudinary使用時
BUNNY_HOSTNAME=xxx.b-cdn.net  # bunny使用時
```

## Test plan
- [ ] Q2で動画が再生できることを確認
- [ ] Q1・Q3〜Q5で画像プレースホルダーが表示されることを確認
- [ ] からだ・ながら を両方選択すると正解になることを確認
- [ ] 1つだけ選択では不正解になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)