### PR TITLE
test(quiz): add vitest/RTL/playwright tests for video feature #33

### DIFF
--- a/docs/test/playwright.md
+++ b/docs/test/playwright.md
@@ -1,0 +1,173 @@
+# Playwright E2E テスト解説
+
+## Playwright とは
+
+**Playwright** は実際のブラウザ（Chromium / Firefox / Safari）を自動操作して、
+アプリ全体を「端から端まで（E2E = End-to-End）」テストするツール。
+
+Vitest（ユニット・コンポーネントテスト）とは異なり、
+**実際のサーバーが動いた状態**でテストする。
+
+---
+
+## Vitest との違い
+
+| | Vitest（ユニット/コンポーネント） | Playwright（E2E） |
+|--|---|---|
+| テスト対象 | 関数・コンポーネント単体 | アプリ全体（画面操作） |
+| 実行速度 | 速い（ミリ秒単位） | 遅い（秒単位） |
+| サーバー | 不要 | 必要（`pnpm dev` を起動） |
+| ブラウザ | 使わない（jsdom でエミュレート） | 実際のブラウザを使う |
+| 用途 | ロジックの正確さ確認 | ユーザー操作の確認 |
+
+---
+
+## テストの実行方法
+
+```bash
+# 開発サーバーを起動した状態で（別ターミナル）
+pnpm dev
+
+# Playwright テストを実行
+pnpm test:e2e
+
+# ブラウザを画面に表示しながら実行（デバッグ時に便利）
+pnpm test:e2e --headed
+
+# 特定のファイルだけ実行
+pnpm test:e2e e2e/quiz-video.spec.ts
+```
+
+---
+
+## 設定ファイル: `playwright.config.ts`
+
+```ts
+export default defineConfig({
+  testDir: "./e2e",       // テストファイルの場所
+  use: {
+    baseURL: "http://localhost:3000",  // テスト対象のURL
+    screenshot: "only-on-failure",    // 失敗時にスクリーンショットを保存
+  },
+  webServer: {
+    command: "pnpm dev",              // テスト前に自動でサーバーを起動
+    url: "http://localhost:3000",
+    reuseExistingServer: true,        // 既に起動中なら再起動しない
+  },
+});
+```
+
+---
+
+## テストの基本構文
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test.describe("グループ名", () => {
+  test("テストの説明", async ({ page }) => {
+    // ページを開く
+    await page.goto("/");
+
+    // 要素を探して操作する
+    await page.getByText("おか").click();
+    await page.getByRole("button", { name: "解答する" }).click();
+
+    // 結果を確認する
+    await expect(page.getByTestId("video-player")).toBeVisible();
+  });
+});
+```
+
+**注意**: Playwright は非同期処理なので `async / await` を使う。
+
+---
+
+## このプロジェクトの E2E テスト: `e2e/quiz-video.spec.ts`
+
+Q2 の動画表示機能をブラウザで確認するテスト。
+
+### テスト 1: Q1 は動画なし
+
+```
+アクセス → / (トップページ = Q1)
+確認:
+  - data-testid="video-player" が見えない
+  - data-testid="image-placeholder" が見える
+```
+
+### テスト 2: Q1 を回答 → Q2 で動画が出る
+
+```
+アクセス → /
+操作:
+  1. 「おか」テキストをクリック（Q1 の正解選択肢）
+  2. 「解答する」ボタンをクリック
+  3. 結果表示を待つ（正解 or 不正解）
+  4. 「次の問題へ」ボタンをクリック
+確認:
+  - 「あたま」（Q2 の問題文）が表示されている
+  - data-testid="video-player" が見える
+  - src 属性に ".mp4" が含まれる
+  - data-testid="image-placeholder" が見えない
+```
+
+---
+
+## よく使う Playwright のメソッド
+
+### ページ操作
+
+| メソッド | 意味 |
+|---------|------|
+| `page.goto("/")` | URL に移動する |
+| `page.getByText("テキスト").click()` | テキストを含む要素をクリック |
+| `page.getByRole("button", { name: "ラベル" }).click()` | ボタンをクリック |
+| `page.getByTestId("name").click()` | `data-testid="name"` の要素をクリック |
+
+### アサーション（確認）
+
+| メソッド | 意味 |
+|---------|------|
+| `expect(locator).toBeVisible()` | 要素が画面に表示されている |
+| `expect(locator).not.toBeVisible()` | 要素が画面に表示されていない |
+| `expect(locator).toHaveAttribute("src", "...")` | 属性値が一致する |
+| `locator.getAttribute("src")` | 属性値を取得する |
+
+### タイムアウト
+
+```ts
+// デフォルトタイムアウトを変えたいとき
+await expect(page.getByText(/あたま/)).toBeVisible({ timeout: 5000 });
+```
+
+非同期で表示される要素（API レスポンス待ちなど）は `timeout` を指定する。
+
+---
+
+## テスト失敗時の確認方法
+
+テストが失敗すると、`e2e/results/` フォルダにスクリーンショットが保存される。
+何が表示されていたかを画像で確認できる。
+
+```bash
+# HTML レポートを開く（テスト後に生成される）
+pnpm exec playwright show-report
+```
+
+---
+
+## `data-testid` について
+
+Playwright でも RTL でも、要素を特定するために `data-testid` 属性を使う。
+
+```tsx
+// コンポーネント側
+<video data-testid="video-player" />
+
+// テスト側
+await expect(page.getByTestId("video-player")).toBeVisible();
+```
+
+`data-testid` はテスト専用の識別子。本番ビルドに含まれても動作には影響しない。
+ただし「テストのためだけに属性を追加する」より、テキストやロールで特定できる場合はそちらが望ましい。

--- a/docs/test/vitest.md
+++ b/docs/test/vitest.md
@@ -1,0 +1,205 @@
+# Vitest テスト解説
+
+## Vitest とは
+
+**Vitest** は Vite 製のテストフレームワーク。
+テストファイルを書いて `pnpm test` を実行すると、コードが「期待通りに動くか」を自動で確認してくれる。
+
+---
+
+## テストの実行方法
+
+```bash
+pnpm test          # 全テストを1回実行
+pnpm test --watch  # ファイルを変更するたびに自動実行（開発中に便利）
+```
+
+---
+
+## このプロジェクトにあるテストファイル一覧
+
+| ファイル | 種類 | 何をテストするか |
+|---------|------|----------------|
+| `src/features/quiz/domain/logic/__tests__/rhyme.test.ts` | ユニット | 母音抽出・正解判定ロジック |
+| `src/features/quiz/domain/logic/__tests__/scoring.test.ts` | ユニット | スコア計算・称号ロジック |
+| `src/features/quiz/infrastructure/media/__tests__/mediaResolver.test.ts` | ユニット | 動画URLの生成（プロバイダー切り替え） |
+| `src/features/quiz/application/services/__tests__/quizService.test.ts` | ユニット（モックあり） | サービス層の videoUrl 解決 |
+| `src/features/quiz/presentation/parts/__tests__/QuizCard.test.tsx` | コンポーネント（RTL） | 動画 / 画像の表示切り替え |
+
+---
+
+## テストの基本構文
+
+```ts
+import { describe, it, expect } from "vitest";
+
+describe("グループ名", () => {       // テストをグループにまとめる
+  it("テストの説明", () => {         // 1つのテストケース
+    expect(実際の値).toBe(期待する値); // アサーション（検証）
+  });
+});
+```
+
+### よく使うアサーション
+
+| 書き方 | 意味 |
+|-------|------|
+| `expect(x).toBe(y)` | `x === y` であること |
+| `expect(x).toBeUndefined()` | `x` が undefined であること |
+| `expect(x).toBeNull()` | `x` が null であること |
+| `expect(x).toContain(y)` | 配列・文字列が `y` を含むこと |
+| `expect(x).toHaveProperty("key")` | オブジェクトに `key` があること |
+| `expect(x).not.toHaveProperty("key")` | オブジェクトに `key` がないこと |
+
+---
+
+## ユニットテスト
+
+**「1つの関数だけ」を切り出してテストする**方法。
+外部への依存（DB、ファイル、API）がないので、速くて安定している。
+
+### 例: `mediaResolver.test.ts`
+
+```ts
+// テスト対象の関数
+// resolveVideoUrl("abc123") → "/video/abc123.mp4"
+
+it("VIDEO_PROVIDER 未設定のとき /video/${key}.mp4 を返す", () => {
+  expect(resolveVideoUrl("abc123")).toBe("/video/abc123.mp4");
+});
+```
+
+#### `vi.stubEnv` — 環境変数を一時的に書き換える
+
+実際の環境変数を変えずに、テスト中だけ別の値を設定できる。
+
+```ts
+vi.stubEnv("VIDEO_PROVIDER", "cloudinary");
+vi.stubEnv("CLOUDINARY_CLOUD_NAME", "mycloud");
+
+// テスト後に元に戻す
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+```
+
+---
+
+## モックを使ったユニットテスト
+
+**「外部依存（DB・ファイル）を偽物に差し替える」**テスト方法。
+実際のデータを使わないので、テスト環境がシンプルで済む。
+
+### 例: `quizService.test.ts`
+
+```ts
+// getRepository() が返す「偽のリポジトリ」を定義する
+vi.mock("../../../infrastructure/getRepository", () => ({
+  getRepository: () => ({
+    findAllQuestions: async () => [
+      { id: "q1", questionWord: "とら", /* ... */ },
+      { id: "q2", videoKey: "test-video-key", /* ... */ },
+    ],
+  }),
+}));
+
+// サービス関数をテスト
+it("videoKey がある問題は videoUrl を含む", async () => {
+  const question = await getQuestionByIndex(1);
+  expect(question?.videoUrl).toBe("/video/test-video-key.mp4");
+});
+```
+
+#### なぜモックが必要か？
+
+- `getQuestionByIndex` は内部で `getRepository()` を呼び、ファイルを読む
+- テスト中に実際のファイルを読むと**テストが遅くなる・環境依存になる**
+- モックで「偽のデータ」を渡せば、関数の振る舞いだけをテストできる
+
+---
+
+## コンポーネントテスト（React Testing Library）
+
+**「React コンポーネントが正しく描画されるか」**をテストする方法。
+実際の DOM に描画して、要素の存在を確認する。
+
+### jsdom とは？
+
+ブラウザ環境を Node.js 上でシミュレートするライブラリ。
+`document`、`window` などのブラウザ API が使えるようになる。
+
+ファイル先頭に以下のコメントを書くと、そのファイルだけ jsdom で実行される:
+
+```ts
+// @vitest-environment jsdom
+```
+
+### 例: `QuizCard.test.tsx`
+
+```tsx
+import { render, screen } from "@testing-library/react";
+
+it("videoUrl があるとき <video> 要素を表示する", () => {
+  render(<QuizCard question={questionWithVideo} />);
+
+  const video = screen.getByTestId("video-player");
+  expect(video).toBeInTheDocument();  // jest-dom のマッチャー
+  expect(video.tagName).toBe("VIDEO");
+});
+```
+
+#### `screen` の主なクエリメソッド
+
+| メソッド | 用途 |
+|---------|------|
+| `screen.getByTestId("name")` | `data-testid="name"` の要素を取得（見つからないとエラー） |
+| `screen.queryByTestId("name")` | 同上（見つからないと `null`、存在しないことの確認に使う） |
+| `screen.getByRole("button", { name: "解答する" })` | role とテキストで要素を取得 |
+| `screen.getByText(/テキスト/)` | テキスト内容で要素を取得 |
+| `screen.getAllByText("テキスト")` | 同名要素が複数ある場合 |
+
+#### `afterEach(cleanup)` — テスト後に DOM をリセット
+
+```ts
+import { cleanup } from "@testing-library/react";
+afterEach(cleanup); // 各テスト後に DOM を空にする
+```
+
+これをしないと、前のテストで描画した要素が残り、次のテストで「複数要素が見つかった」エラーになる。
+
+#### `beforeEach` で Zustand ストアをリセット
+
+```ts
+beforeEach(() => {
+  useQuizStore.getState().reset(); // Zustand の状態を初期化
+});
+```
+
+グローバルな状態（Zustand ストア）はテスト間で共有されるため、毎回リセットする。
+
+#### Provider でのラップ
+
+TanStack Query の `useMutation` を使うコンポーネントは `QueryClientProvider` で包む必要がある:
+
+```tsx
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  );
+}
+```
+
+---
+
+## jest-dom マッチャー
+
+`@testing-library/jest-dom` が提供する追加のアサーション。
+`src/test/setup.ts` でインポートしているため、全テストで使える。
+
+| マッチャー | 意味 |
+|-----------|------|
+| `expect(el).toBeInTheDocument()` | 要素が DOM に存在する |
+| `expect(el).not.toBeInTheDocument()` | 要素が DOM に存在しない |
+| `expect(el).toHaveAttribute("src", "/video/x.mp4")` | 属性値が一致する |
+| `expect(el).toBeDisabled()` | disabled 状態である |

--- a/e2e/quiz-video.spec.ts
+++ b/e2e/quiz-video.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * クイズ動画表示の E2E テスト（Playwright）
+ *
+ * E2E（End-to-End）テスト: 実際のブラウザを操作して、
+ * ユーザーの操作から画面の変化まで「端から端まで」テストする。
+ *
+ * このテストでは:
+ * 1. Q1（とら）に動画がないことを確認する
+ * 2. Q1 を回答して Q2 へ進む
+ * 3. Q2（あたま）に動画が表示されることを確認する
+ */
+import { expect, test } from "@playwright/test";
+
+test.describe("クイズ動画表示", () => {
+	test("Q1 では動画が表示されず、画像プレースホルダーが表示される", async ({
+		page,
+	}) => {
+		await page.goto("/");
+
+		// Q1 の問題文が表示されていることを確認
+		await expect(page.getByText(/とら/)).toBeVisible();
+
+		// video 要素は存在しない
+		await expect(page.getByTestId("video-player")).not.toBeVisible();
+
+		// 画像プレースホルダーは表示されている
+		await expect(page.getByTestId("image-placeholder")).toBeVisible();
+	});
+
+	test("Q1 を回答して Q2 に進むと動画が表示される", async ({ page }) => {
+		await page.goto("/");
+
+		// --- Q1 を回答する ---
+		// 選択肢「おか」を選ぶ（shuffleされているのでテキストで検索）
+		await page.getByText("おか").click();
+
+		// 「解答する」ボタンをクリック
+		await page.getByRole("button", { name: "解答する" }).click();
+
+		// 結果表示を待つ（正解/不正解の表示）
+		await expect(
+			page.getByText(/正解|不正解/).first(),
+		).toBeVisible({ timeout: 5000 });
+
+		// 「次の問題へ」ボタンをクリック
+		await page.getByRole("button", { name: "次の問題へ" }).click();
+
+		// --- Q2 を確認する ---
+		// Q2 の問題文「あたま」が表示されていることを確認
+		await expect(page.getByText(/あたま/)).toBeVisible({ timeout: 5000 });
+
+		// <video> 要素が表示されている
+		const video = page.getByTestId("video-player");
+		await expect(video).toBeVisible();
+
+		// src 属性が動画ファイルを指していることを確認
+		const src = await video.getAttribute("src");
+		expect(src).toContain(".mp4");
+
+		// 画像プレースホルダーは表示されていない
+		await expect(page.getByTestId("image-placeholder")).not.toBeVisible();
+	});
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "format": "biome format",
     "lint": "biome lint",
     "check": "biome check",
@@ -39,8 +40,10 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
+    "@playwright/test": "^1.58.2",
     "@tanstack/devtools-vite": "^0.3.11",
     "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.2.0",
     "@types/node": "^22.10.2",
     "@types/react": "^19.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,43 @@
+/**
+ * Playwright の設定ファイル
+ *
+ * Playwright は実際のブラウザ（Chromium/Firefox/Safari）を操作して
+ * アプリ全体を E2E（End-to-End）でテストするツール。
+ *
+ * webServer: テスト実行前に自動で開発サーバーを起動する設定。
+ */
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+	// テストファイルの場所
+	testDir: "./e2e",
+	// テスト失敗時のスクリーンショット等を保存するフォルダ
+	outputDir: "./e2e/results",
+	// テスト結果レポートの形式
+	reporter: "html",
+
+	use: {
+		// テスト対象の URL
+		baseURL: "http://localhost:3000",
+		// テスト失敗時に自動でスクリーンショットを取る
+		screenshot: "only-on-failure",
+		// テスト失敗時に操作履歴（trace）を保存する
+		trace: "on-first-retry",
+	},
+
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+	],
+
+	// テスト実行前に開発サーバーを起動する
+	// 既にサーバーが起動している場合は再起動しない
+	webServer: {
+		command: "pnpm dev",
+		url: "http://localhost:3000",
+		reuseExistingServer: true,
+		timeout: 30_000,
+	},
+});

--- a/src/features/quiz/application/services/__tests__/quizService.test.ts
+++ b/src/features/quiz/application/services/__tests__/quizService.test.ts
@@ -1,0 +1,73 @@
+/**
+ * quizService のユニットテスト
+ *
+ * テスト対象: getQuestionByIndex(index) 関数
+ * - videoKey を持つ問題は videoUrl を返すことを検証する
+ * - videoKey を持たない問題は videoUrl を返さないことを検証する
+ *
+ * vi.mock() でリポジトリ（DB/ファイルアクセス）を差し替えることで、
+ * 実際のデータファイルを使わずに関数の振る舞いだけをテストする
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { getQuestionByIndex } from "../quizService";
+
+// getRepository() が返すリポジトリをモック（偽物）に差し替える
+vi.mock("../../../infrastructure/getRepository", () => ({
+	getRepository: () => ({
+		findAllQuestions: async () => [
+			// videoKey なし（画像プレースホルダーを表示する問題）
+			{
+				id: "q1",
+				questionWord: "とら",
+				questionVowels: "おあ",
+				imageKey: "tora",
+				explanation: "テスト用",
+				choices: [{ id: "c1", text: "おか", vowels: "おあ", isCorrect: true }],
+			},
+			// videoKey あり（動画を表示する問題）
+			{
+				id: "q2",
+				questionWord: "あたま",
+				questionVowels: "あああ",
+				imageKey: "",
+				videoKey: "test-video-key",
+				explanation: "テスト用",
+				choices: [{ id: "c1", text: "からだ", vowels: "あああ", isCorrect: true }],
+			},
+		],
+		findFullById: async () => null,
+	}),
+}));
+
+describe("getQuestionByIndex", () => {
+	it("videoKey がある問題は videoUrl を含む", async () => {
+		const question = await getQuestionByIndex(1);
+		// VIDEO_PROVIDER 未設定 → local → /video/${key}.mp4 になる
+		expect(question?.videoUrl).toBe("/video/test-video-key.mp4");
+	});
+
+	it("videoKey がない問題は videoUrl が undefined", async () => {
+		const question = await getQuestionByIndex(0);
+		expect(question?.videoUrl).toBeUndefined();
+	});
+
+	it("存在しないインデックスは null を返す", async () => {
+		const question = await getQuestionByIndex(99);
+		expect(question).toBeNull();
+	});
+
+	it("questionWord を正しく返す", async () => {
+		const question = await getQuestionByIndex(0);
+		expect(question?.questionWord).toBe("とら");
+	});
+
+	it("choices に isCorrect などサーバー情報が含まれない（クライアントへは id と text のみ）", async () => {
+		const question = await getQuestionByIndex(0);
+		const choice = question?.choices[0];
+		// isCorrect はクライアントに渡さない（正解情報の秘匿）
+		expect(choice).not.toHaveProperty("isCorrect");
+		expect(choice).toHaveProperty("id");
+		expect(choice).toHaveProperty("text");
+	});
+});

--- a/src/features/quiz/infrastructure/media/__tests__/mediaResolver.test.ts
+++ b/src/features/quiz/infrastructure/media/__tests__/mediaResolver.test.ts
@@ -1,0 +1,48 @@
+/**
+ * mediaResolver のユニットテスト
+ *
+ * テスト対象: resolveVideoUrl(key) 関数
+ * - VIDEO_PROVIDER 環境変数に応じて異なる URL を返すことを検証する
+ * - vi.stubEnv() で環境変数を一時的に書き換えて各プロバイダーの挙動を確認する
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveVideoUrl } from "../mediaResolver";
+
+describe("resolveVideoUrl", () => {
+	// 各テスト後に環境変数の書き換えをリセットする
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("VIDEO_PROVIDER 未設定のとき /video/${key}.mp4 を返す", () => {
+		// デフォルト（local）: public/video/ ディレクトリのファイルを参照する
+		expect(resolveVideoUrl("abc123")).toBe("/video/abc123.mp4");
+	});
+
+	it("VIDEO_PROVIDER=local のとき /video/${key}.mp4 を返す", () => {
+		vi.stubEnv("VIDEO_PROVIDER", "local");
+		expect(resolveVideoUrl("abc123")).toBe("/video/abc123.mp4");
+	});
+
+	it("VIDEO_PROVIDER=cloudinary のとき Cloudinary 動画 URL を返す", () => {
+		vi.stubEnv("VIDEO_PROVIDER", "cloudinary");
+		vi.stubEnv("CLOUDINARY_CLOUD_NAME", "mycloud");
+		expect(resolveVideoUrl("abc123")).toBe(
+			"https://res.cloudinary.com/mycloud/video/upload/abc123.mp4",
+		);
+	});
+
+	it("VIDEO_PROVIDER=bunny のとき Bunny Stream URL を返す", () => {
+		vi.stubEnv("VIDEO_PROVIDER", "bunny");
+		vi.stubEnv("BUNNY_HOSTNAME", "myzone.b-cdn.net");
+		expect(resolveVideoUrl("abc123")).toBe(
+			"https://myzone.b-cdn.net/abc123.mp4",
+		);
+	});
+
+	it("key が長い文字列でも URL に正しく含まれる", () => {
+		const key = "20260226_1254_01kjb86c8mf86rdf15zcrvc52b";
+		expect(resolveVideoUrl(key)).toBe(`/video/${key}.mp4`);
+	});
+});

--- a/src/features/quiz/presentation/parts/QuizCard.tsx
+++ b/src/features/quiz/presentation/parts/QuizCard.tsx
@@ -43,11 +43,15 @@ export function QuizCard({ question }: QuizCardProps) {
 								src={question.videoUrl}
 								controls
 								className="w-full max-w-sm rounded-lg"
+								data-testid="video-player"
 							/>
 						</div>
 					) : (
 						<div className="flex justify-center">
-							<div className="w-40 h-40 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300">
+							<div
+								className="w-40 h-40 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300"
+								data-testid="image-placeholder"
+							>
 								<ImageIcon className="w-12 h-12 text-gray-400" />
 							</div>
 						</div>

--- a/src/features/quiz/presentation/parts/__tests__/QuizCard.test.tsx
+++ b/src/features/quiz/presentation/parts/__tests__/QuizCard.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+/**
+ * QuizCard コンポーネントテスト（React Testing Library）
+ *
+ * テスト対象: QuizCard コンポーネントの描画ロジック
+ * - question.videoUrl がある → <video> を表示する
+ * - question.videoUrl がない → 画像プレースホルダーを表示する
+ *
+ * React Testing Library（RTL）は「ユーザーが見る画面」に近い形でテストする。
+ * 実際の DOM に描画して、要素の存在を確認する。
+ *
+ * // @vitest-environment jsdom
+ * このコメントにより、このファイルだけ jsdom（ブラウザ環境エミュレーション）で実行される。
+ * jsdom がないと document や window が存在せず React のレンダリングが動かない。
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { QuizQuestion } from "../../../contracts/quiz";
+import { useQuizStore } from "../../hooks/useQuiz";
+import { QuizCard } from "../QuizCard";
+
+// 各テスト後に DOM をリセットする（テスト間の状態汚染を防ぐ）
+afterEach(cleanup);
+
+// TanStack Query の Provider でラップする（useSubmitAnswer が内部で useMutation を使うため）
+function renderWithProviders(ui: React.ReactElement) {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return render(
+		<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+	);
+}
+
+// テスト用の問題データ（videoUrl あり）
+const questionWithVideo: QuizQuestion = {
+	id: "q2",
+	questionWord: "あたま",
+	imageKey: "",
+	videoUrl: "/video/test-video.mp4",
+	choices: [
+		{ id: "c1", text: "からだ" },
+		{ id: "c2", text: "ながら" },
+	],
+	total: 5,
+	index: 1,
+};
+
+// テスト用の問題データ（videoUrl なし）
+const questionWithoutVideo: QuizQuestion = {
+	id: "q1",
+	questionWord: "とら",
+	imageKey: "tora",
+	choices: [
+		{ id: "c1", text: "おか" },
+		{ id: "c2", text: "ぶた" },
+	],
+	total: 5,
+	index: 0,
+};
+
+describe("QuizCard", () => {
+	// 各テスト前に Zustand ストアをリセットする
+	// （テスト間で selectedChoiceIds などの状態が残らないようにする）
+	beforeEach(() => {
+		useQuizStore.getState().reset();
+	});
+
+	describe("動画表示", () => {
+		it("videoUrl があるとき <video> 要素を表示する", () => {
+			renderWithProviders(<QuizCard question={questionWithVideo} />);
+
+			const video = screen.getByTestId("video-player");
+			expect(video).toBeInTheDocument();
+			expect(video.tagName).toBe("VIDEO");
+		});
+
+		it("videoUrl があるとき src 属性が正しく設定される", () => {
+			renderWithProviders(<QuizCard question={questionWithVideo} />);
+
+			const video = screen.getByTestId("video-player");
+			expect(video).toHaveAttribute("src", "/video/test-video.mp4");
+		});
+
+		it("videoUrl があるとき画像プレースホルダーは表示しない", () => {
+			renderWithProviders(<QuizCard question={questionWithVideo} />);
+
+			expect(screen.queryByTestId("image-placeholder")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("画像プレースホルダー表示", () => {
+		it("videoUrl がないとき画像プレースホルダーを表示する", () => {
+			renderWithProviders(<QuizCard question={questionWithoutVideo} />);
+
+			expect(screen.getByTestId("image-placeholder")).toBeInTheDocument();
+		});
+
+		it("videoUrl がないとき <video> 要素は表示しない", () => {
+			renderWithProviders(<QuizCard question={questionWithoutVideo} />);
+
+			expect(screen.queryByTestId("video-player")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("問題文表示", () => {
+		it("questionWord がカードタイトルに表示される", () => {
+			renderWithProviders(<QuizCard question={questionWithVideo} />);
+
+			expect(screen.getByText(/あたま/)).toBeInTheDocument();
+		});
+
+		it("すべての選択肢テキストが表示される", () => {
+			renderWithProviders(<QuizCard question={questionWithVideo} />);
+
+			// getAllByText で複数マッチを許容しつつ存在確認
+			expect(screen.getAllByText("からだ").length).toBeGreaterThan(0);
+			expect(screen.getAllByText("ながら").length).toBeGreaterThan(0);
+		});
+	});
+
+	describe("解答ボタン", () => {
+		it("初期状態では「解答する」ボタンが無効化されている", () => {
+			renderWithProviders(<QuizCard question={questionWithVideo} />);
+
+			// 選択肢を何も選んでいないのでボタンは disabled
+			const button = screen.getByRole("button", { name: "解答する" });
+			expect(button).toBeDisabled();
+		});
+	});
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,3 @@
+// @testing-library/jest-dom のカスタムマッチャーを vitest に登録する
+// これにより toBeInTheDocument() などが使えるようになる
+import "@testing-library/jest-dom/vitest";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,12 @@ import tsconfigPaths from "vite-tsconfig-paths"
 export default defineConfig({
 	plugins: [tsconfigPaths()],
 	test: {
+		// デフォルトは node 環境
+		// コンポーネントテスト（.tsx）は各ファイル先頭の @vitest-environment jsdom コメントで個別指定する
 		environment: "node",
+		// jest-dom のカスタムマッチャーをすべてのテストで使えるようにする
+		setupFiles: ["./src/test/setup.ts"],
+		// Playwright テストファイル（e2e/）は vitest の対象外にする
+		exclude: ["node_modules", "e2e/**"],
 	},
 })


### PR DESCRIPTION
## Summary
動画表示機能（#33）に対するテストとドキュメントを追加。

### 追加したテスト（3種類）

#### 1. Vitest ユニットテスト
- `mediaResolver.test.ts` — `resolveVideoUrl()` が local/cloudinary/bunny 各プロバイダーで正しい URL を返すか確認（5ケース）
- `quizService.test.ts` — `getQuestionByIndex()` が videoKey を videoUrl に変換してクライアントへ返すか確認（5ケース）

#### 2. React Testing Library コンポーネントテスト
- `QuizCard.test.tsx` — videoUrl あり→`<video>` 表示 / なし→画像プレースホルダー表示の描画ロジック確認（8ケース）

#### 3. Playwright E2E テスト
- `e2e/quiz-video.spec.ts` — 実ブラウザで Q1（動画なし）→ Q2（動画あり）の画面遷移を確認（2ケース）

### 追加したドキュメント
- `docs/test/vitest.md` — Vitest ユニット・コンポーネントテストの仕組みをゼロから解説
- `docs/test/playwright.md` — Playwright E2E テストの仕組みをゼロから解説

### その他の変更
- `QuizCard.tsx` — `<video>` に `data-testid="video-player"`、画像プレースホルダーに `data-testid="image-placeholder"` を追加
- `vitest.config.ts` — `setupFiles`・`exclude` を追加（jest-dom のセットアップ、e2e ディレクトリを vitest 対象外に）
- `package.json` — `test:e2e` スクリプトを追加

## Test plan
- [x] `pnpm test` で全39ケース通過を確認
- [ ] `pnpm test:e2e` で Playwright テスト確認（開発サーバー起動が必要）

## 実行方法
```bash
# Vitest（ユニット + コンポーネント）
pnpm test

# Playwright（E2E） ← 開発サーバーが必要
pnpm dev          # 別ターミナルで
pnpm test:e2e
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)