### PR TITLE
feat(quiz): 問題文に画像を追加 #27

### DIFF
--- a/src/features/quiz/application/services/quizService.ts
+++ b/src/features/quiz/application/services/quizService.ts
@@ -1,5 +1,5 @@
 import type { QuizResult } from "../../domain/entities/quiz"
-import { resolveVideoUrl } from "../../infrastructure/media/mediaResolver"
+import { resolveImageUrl, resolveVideoUrl } from "../../infrastructure/media/mediaResolver"
 import { judgeAnswer } from "../../domain/logic/rhyme"
 import { getRepository } from "../../infrastructure/getRepository"
 
@@ -7,6 +7,7 @@ export interface QuestionForClient {
 	id: string
 	questionWord: string
 	imageKey: string
+	imageUrl?: string
 	videoUrl?: string
 	choices: Array<{ id: string; text: string }>
 	total: number
@@ -29,6 +30,7 @@ export async function getQuestionByIndex(
 		id: quiz.id,
 		questionWord: quiz.questionWord,
 		imageKey: quiz.imageKey,
+		...(quiz.imageKey ? { imageUrl: resolveImageUrl(quiz.imageKey) } : {}),
 		...(quiz.videoKey ? { videoUrl: resolveVideoUrl(quiz.videoKey) } : {}),
 		choices: shuffledChoices,
 		total: allQuizzes.length,

--- a/src/features/quiz/contracts/quiz.ts
+++ b/src/features/quiz/contracts/quiz.ts
@@ -9,6 +9,7 @@ export const QuizQuestionSchema = z.object({
 	id: z.string(),
 	questionWord: z.string(),
 	imageKey: z.string(),
+	imageUrl: z.string().optional(),
 	videoUrl: z.string().optional(),
 	choices: z.array(ChoiceSchema),
 	total: z.number(),

--- a/src/features/quiz/infrastructure/media/__tests__/mediaResolver.test.ts
+++ b/src/features/quiz/infrastructure/media/__tests__/mediaResolver.test.ts
@@ -7,7 +7,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { resolveVideoUrl } from "../mediaResolver";
+import { resolveImageUrl, resolveVideoUrl } from "../mediaResolver";
 
 describe("resolveVideoUrl", () => {
 	// 各テスト後に環境変数の書き換えをリセットする
@@ -44,5 +44,32 @@ describe("resolveVideoUrl", () => {
 	it("key が長い文字列でも URL に正しく含まれる", () => {
 		const key = "20260226_1254_01kjb86c8mf86rdf15zcrvc52b";
 		expect(resolveVideoUrl(key)).toBe(`/video/${key}.mp4`);
+	});
+});
+
+describe("resolveImageUrl", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("IMAGE_PROVIDER 未設定のとき /images/${key}.jpg を返す", () => {
+		expect(resolveImageUrl("tora")).toBe("/images/tora.jpg");
+	});
+
+	it("IMAGE_PROVIDER=local のとき /images/${key}.jpg を返す", () => {
+		vi.stubEnv("IMAGE_PROVIDER", "local");
+		expect(resolveImageUrl("tora")).toBe("/images/tora.jpg");
+	});
+
+	it("IMAGE_PROVIDER=cloudinary のとき Cloudinary 画像 URL を返す", () => {
+		vi.stubEnv("IMAGE_PROVIDER", "cloudinary");
+		vi.stubEnv("CLOUDINARY_CLOUD_NAME", "mycloud");
+		expect(resolveImageUrl("tora")).toBe(
+			"https://res.cloudinary.com/mycloud/image/upload/tora.jpg",
+		);
+	});
+
+	it("key が空文字のとき空文字を返す", () => {
+		expect(resolveImageUrl("")).toBe("");
 	});
 });

--- a/src/features/quiz/infrastructure/media/mediaResolver.ts
+++ b/src/features/quiz/infrastructure/media/mediaResolver.ts
@@ -1,7 +1,24 @@
 export type VideoProvider = "local" | "cloudinary" | "bunny";
+export type ImageProvider = "local" | "cloudinary";
 
 function getVideoProvider(): VideoProvider {
 	return (process.env.VIDEO_PROVIDER as VideoProvider) ?? "local";
+}
+
+function getImageProvider(): ImageProvider {
+	return (process.env.IMAGE_PROVIDER as ImageProvider) ?? "local";
+}
+
+export function resolveImageUrl(key: string): string {
+	if (!key) return "";
+	const provider = getImageProvider();
+	switch (provider) {
+		case "cloudinary":
+			return `https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/upload/${key}.jpg`;
+		case "local":
+		default:
+			return `/images/${key}.jpg`;
+	}
 }
 
 export function resolveVideoUrl(key: string): string {

--- a/src/features/quiz/presentation/parts/QuizCard.tsx
+++ b/src/features/quiz/presentation/parts/QuizCard.tsx
@@ -46,6 +46,15 @@ export function QuizCard({ question }: QuizCardProps) {
 								data-testid="video-player"
 							/>
 						</div>
+					) : question.imageUrl ? (
+						<div className="flex justify-center">
+							<img
+								src={question.imageUrl}
+								alt={question.questionWord}
+								className="w-full max-w-sm rounded-lg object-contain h-48"
+								data-testid="question-image"
+							/>
+						</div>
 					) : (
 						<div className="flex justify-center">
 							<div

--- a/src/features/quiz/presentation/parts/__tests__/QuizCard.test.tsx
+++ b/src/features/quiz/presentation/parts/__tests__/QuizCard.test.tsx
@@ -3,8 +3,9 @@
  * QuizCard コンポーネントテスト（React Testing Library）
  *
  * テスト対象: QuizCard コンポーネントの描画ロジック
- * - question.videoUrl がある → <video> を表示する
- * - question.videoUrl がない → 画像プレースホルダーを表示する
+ * - question.videoUrl がある              → <video> を表示する
+ * - question.imageUrl がある（動画なし）  → <img> を表示する
+ * - imageUrl も videoUrl もない           → 画像プレースホルダーを表示する
  *
  * React Testing Library（RTL）は「ユーザーが見る画面」に近い形でテストする。
  * 実際の DOM に描画して、要素の存在を確認する。
@@ -48,11 +49,25 @@ const questionWithVideo: QuizQuestion = {
 	index: 1,
 };
 
-// テスト用の問題データ（videoUrl なし）
-const questionWithoutVideo: QuizQuestion = {
+// テスト用の問題データ（imageUrl あり・videoUrl なし）
+const questionWithImage: QuizQuestion = {
 	id: "q1",
 	questionWord: "とら",
 	imageKey: "tora",
+	imageUrl: "/images/tora.jpg",
+	choices: [
+		{ id: "c1", text: "おか" },
+		{ id: "c2", text: "ぶた" },
+	],
+	total: 5,
+	index: 0,
+};
+
+// テスト用の問題データ（videoUrl も imageUrl もなし）
+const questionWithNoMedia: QuizQuestion = {
+	id: "q1",
+	questionWord: "とら",
+	imageKey: "",
 	choices: [
 		{ id: "c1", text: "おか" },
 		{ id: "c2", text: "ぶた" },
@@ -91,17 +106,59 @@ describe("QuizCard", () => {
 		});
 	});
 
+	describe("画像表示", () => {
+		it("imageUrl があり videoUrl がないとき <img> を表示する", () => {
+			renderWithProviders(<QuizCard question={questionWithImage} />);
+
+			const img = screen.getByTestId("question-image");
+			expect(img).toBeInTheDocument();
+			expect(img.tagName).toBe("IMG");
+		});
+
+		it("imageUrl の <img> は正しい src 属性を持つ", () => {
+			renderWithProviders(<QuizCard question={questionWithImage} />);
+
+			const img = screen.getByTestId("question-image");
+			expect(img).toHaveAttribute("src", "/images/tora.jpg");
+		});
+
+		it("imageUrl の <img> は alt 属性に questionWord を持つ", () => {
+			renderWithProviders(<QuizCard question={questionWithImage} />);
+
+			const img = screen.getByTestId("question-image");
+			expect(img).toHaveAttribute("alt", "とら");
+		});
+
+		it("imageUrl があるとき <video> は表示しない", () => {
+			renderWithProviders(<QuizCard question={questionWithImage} />);
+
+			expect(screen.queryByTestId("video-player")).not.toBeInTheDocument();
+		});
+
+		it("imageUrl があるとき画像プレースホルダーは表示しない", () => {
+			renderWithProviders(<QuizCard question={questionWithImage} />);
+
+			expect(screen.queryByTestId("image-placeholder")).not.toBeInTheDocument();
+		});
+	});
+
 	describe("画像プレースホルダー表示", () => {
-		it("videoUrl がないとき画像プレースホルダーを表示する", () => {
-			renderWithProviders(<QuizCard question={questionWithoutVideo} />);
+		it("videoUrl も imageUrl もないとき画像プレースホルダーを表示する", () => {
+			renderWithProviders(<QuizCard question={questionWithNoMedia} />);
 
 			expect(screen.getByTestId("image-placeholder")).toBeInTheDocument();
 		});
 
-		it("videoUrl がないとき <video> 要素は表示しない", () => {
-			renderWithProviders(<QuizCard question={questionWithoutVideo} />);
+		it("videoUrl も imageUrl もないとき <video> 要素は表示しない", () => {
+			renderWithProviders(<QuizCard question={questionWithNoMedia} />);
 
 			expect(screen.queryByTestId("video-player")).not.toBeInTheDocument();
+		});
+
+		it("videoUrl も imageUrl もないとき <img> 要素は表示しない", () => {
+			renderWithProviders(<QuizCard question={questionWithNoMedia} />);
+
+			expect(screen.queryByTestId("question-image")).not.toBeInTheDocument();
 		});
 	});
 


### PR DESCRIPTION
## 概要

問題文に画像を表示する機能を追加しました。

## 変更点

- `mediaResolver.ts` に `resolveImageUrl` を追加（`IMAGE_PROVIDER` 環境変数で local/cloudinary を切り替え可能、将来の Cloudflare R2 等への拡張を想定した設計）
- `contracts/quiz.ts` の `QuizQuestionSchema` に `imageUrl: z.string().optional()` を追加
- `quizService.ts` で `imageKey` から `imageUrl` を生成して API レスポンスに含める
- `QuizCard.tsx` で動画なしかつ `imageUrl` あり のとき `<img>` を表示（優先順位: 動画 > 画像 > プレースホルダー）
- `mediaResolver.test.ts` に `resolveImageUrl` のテストを追加（未設定・local・cloudinary・空文字の4パターン）
- `QuizCard.test.tsx` を更新（画像あり・メディアなしのシナリオを追加）

## テスト内容

- `pnpm test`: 49テスト全パス
- `npx tsc --noEmit`: 型エラー0件
- `pnpm build`: ビルド成功

Closes #27