### PR TITLE
feat(quiz): 問題文に画像を追加する

### DIFF
--- a/docs/test/image.md
+++ b/docs/test/image.md
@@ -1,0 +1,91 @@
+# 画像機能のテスト解説
+
+## 概要
+
+クイズ問題に画像を表示する機能のテストについて説明します。
+画像の URL 解決（`imageResolver`）と画像の表示ロジック（`QuizCard`）の2つをテストします。
+
+---
+
+## 1. imageResolver のテスト
+
+**ファイル**: `src/features/quiz/infrastructure/media/__tests__/imageResolver.test.ts`
+
+### テスト対象
+
+`resolveImageUrl(key: string): string` 関数。
+環境変数 `IMAGE_PROVIDER` に応じて異なる URL を生成する。
+
+### 画像プロバイダー一覧
+
+| プロバイダー | 説明 | URL 例 |
+|---|---|---|
+| `local`（デフォルト） | `public/images/` 以下のファイルを参照 | `/images/tora.jpg` |
+| `cloudflare-r2` | Cloudflare R2 パブリックバケットを参照 | `https://{R2_URL}/tora.jpg` |
+
+### 環境変数
+
+| 変数名 | 説明 | 例 |
+|---|---|---|
+| `IMAGE_PROVIDER` | 使用するプロバイダー（省略時は `local`） | `cloudflare-r2` |
+| `CLOUDFLARE_R2_PUBLIC_URL` | R2 パブリックバケットのドメイン | `pub-abc123.r2.dev` |
+
+### テストケース
+
+| テスト名 | 検証内容 |
+|---|---|
+| IMAGE_PROVIDER 未設定 | ローカルパス `/images/tora.jpg` を返す |
+| IMAGE_PROVIDER=local | ローカルパス `/images/tora.jpg` を返す |
+| IMAGE_PROVIDER=cloudflare-r2 | `https://{R2_URL}/tora.jpg` を返す |
+| 異なる imageKey | key がそのまま URL に含まれることを確認 |
+| 別ドメインの R2 | カスタムドメインでも正しく URL を構築できる |
+
+### なぜこのテストが必要か
+
+`imageResolver` は将来 Cloudflare R2 へ移行する際の差し替えポイントです。
+環境変数を切り替えるだけで本番環境とローカルの動作を分けられることを保証します。
+`vi.stubEnv()` で環境変数を一時的に書き換え、テスト後に `vi.unstubAllEnvs()` でリセットします。
+
+---
+
+## 2. QuizCard の画像表示テスト
+
+**ファイル**: `src/features/quiz/presentation/parts/__tests__/QuizCard.test.tsx`
+
+### 表示ロジック
+
+| 条件 | 表示内容 | testid |
+|---|---|---|
+| `videoUrl` あり | `<video>` 要素 | `video-player` |
+| `imageUrl` あり（videoUrl なし） | `<img>` 要素 | `image-display` |
+| `imageUrl` の読み込みエラー | 画像プレースホルダー | `image-placeholder` |
+| どちらもなし | 画像プレースホルダー | `image-placeholder` |
+
+### テストケース（画像表示グループ）
+
+| テスト名 | 検証内容 |
+|---|---|
+| imageUrl があるとき `<img>` を表示する | `image-display` testid で `<IMG>` タグを確認 |
+| src 属性が正しく設定される | `src="/images/tora.jpg"` を確認 |
+| alt 属性が questionWord に設定される | `alt="とら"` を確認（アクセシビリティ） |
+| 画像プレースホルダーは表示しない | `image-placeholder` が DOM にないことを確認 |
+| `<video>` 要素は表示しない | `video-player` が DOM にないことを確認 |
+| 画像読み込みエラー時にプレースホルダーを表示する | `fireEvent.error(img)` でエラーをシミュレート |
+
+### 画像読み込みエラーのテスト
+
+jsdom 環境では実際の画像ファイルを読み込まないため、`fireEvent.error(img)` で `onError` イベントを手動発火します。
+これにより画像が存在しないサーバー環境でもプレースホルダーにフォールバックすることを保証します。
+
+---
+
+## 3. 現在の画像ファイル配置
+
+```
+public/
+└── images/
+    └── tora.jpg   ← Q1（とら）の画像
+```
+
+将来的には Cloudflare R2 にすべての画像をアップロードし、
+`IMAGE_PROVIDER=cloudflare-r2` に設定することでローカルファイルなしで動作します。

--- a/src/features/quiz/application/services/quizService.ts
+++ b/src/features/quiz/application/services/quizService.ts
@@ -1,4 +1,5 @@
 import type { QuizResult } from "../../domain/entities/quiz"
+import { resolveImageUrl } from "../../infrastructure/media/imageResolver"
 import { resolveVideoUrl } from "../../infrastructure/media/mediaResolver"
 import { judgeAnswer } from "../../domain/logic/rhyme"
 import { getRepository } from "../../infrastructure/getRepository"
@@ -7,6 +8,7 @@ export interface QuestionForClient {
 	id: string
 	questionWord: string
 	imageKey: string
+	imageUrl?: string
 	videoUrl?: string
 	choices: Array<{ id: string; text: string }>
 	total: number
@@ -29,6 +31,7 @@ export async function getQuestionByIndex(
 		id: quiz.id,
 		questionWord: quiz.questionWord,
 		imageKey: quiz.imageKey,
+		...(quiz.imageKey ? { imageUrl: resolveImageUrl(quiz.imageKey) } : {}),
 		...(quiz.videoKey ? { videoUrl: resolveVideoUrl(quiz.videoKey) } : {}),
 		choices: shuffledChoices,
 		total: allQuizzes.length,

--- a/src/features/quiz/contracts/quiz.ts
+++ b/src/features/quiz/contracts/quiz.ts
@@ -9,6 +9,7 @@ export const QuizQuestionSchema = z.object({
 	id: z.string(),
 	questionWord: z.string(),
 	imageKey: z.string(),
+	imageUrl: z.string().optional(),
 	videoUrl: z.string().optional(),
 	choices: z.array(ChoiceSchema),
 	total: z.number(),

--- a/src/features/quiz/infrastructure/media/__tests__/imageResolver.test.ts
+++ b/src/features/quiz/infrastructure/media/__tests__/imageResolver.test.ts
@@ -1,0 +1,45 @@
+/**
+ * imageResolver のユニットテスト
+ *
+ * テスト対象: resolveImageUrl(key) 関数
+ * - IMAGE_PROVIDER 環境変数に応じて異なる URL を返すことを検証する
+ * - vi.stubEnv() で環境変数を一時的に書き換えて各プロバイダーの挙動を確認する
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveImageUrl } from "../imageResolver";
+
+describe("resolveImageUrl", () => {
+	// 各テスト後に環境変数の書き換えをリセットする
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("IMAGE_PROVIDER 未設定のとき /images/${key}.jpg を返す", () => {
+		// デフォルト（local）: public/images/ ディレクトリのファイルを参照する
+		expect(resolveImageUrl("tora")).toBe("/images/tora.jpg");
+	});
+
+	it("IMAGE_PROVIDER=local のとき /images/${key}.jpg を返す", () => {
+		vi.stubEnv("IMAGE_PROVIDER", "local");
+		expect(resolveImageUrl("tora")).toBe("/images/tora.jpg");
+	});
+
+	it("IMAGE_PROVIDER=cloudflare-r2 のとき Cloudflare R2 画像 URL を返す", () => {
+		vi.stubEnv("IMAGE_PROVIDER", "cloudflare-r2");
+		vi.stubEnv("CLOUDFLARE_R2_PUBLIC_URL", "pub-abc123.r2.dev");
+		expect(resolveImageUrl("tora")).toBe(
+			"https://pub-abc123.r2.dev/tora.jpg",
+		);
+	});
+
+	it("key が異なる画像でも URL に正しく含まれる", () => {
+		expect(resolveImageUrl("umikaze")).toBe("/images/umikaze.jpg");
+	});
+
+	it("CLOUDFLARE_R2_PUBLIC_URL が別のドメインでも正しく URL を構築する", () => {
+		vi.stubEnv("IMAGE_PROVIDER", "cloudflare-r2");
+		vi.stubEnv("CLOUDFLARE_R2_PUBLIC_URL", "images.example.com");
+		expect(resolveImageUrl("tora")).toBe("https://images.example.com/tora.jpg");
+	});
+});

--- a/src/features/quiz/infrastructure/media/imageResolver.ts
+++ b/src/features/quiz/infrastructure/media/imageResolver.ts
@@ -1,0 +1,16 @@
+export type ImageProvider = "local" | "cloudflare-r2";
+
+function getImageProvider(): ImageProvider {
+	return (process.env.IMAGE_PROVIDER as ImageProvider) ?? "local";
+}
+
+export function resolveImageUrl(key: string): string {
+	const provider = getImageProvider();
+	switch (provider) {
+		case "cloudflare-r2":
+			return `https://${process.env.CLOUDFLARE_R2_PUBLIC_URL}/${key}.jpg`;
+		case "local":
+		default:
+			return `/images/${key}.jpg`;
+	}
+}

--- a/src/features/quiz/presentation/parts/QuizCard.tsx
+++ b/src/features/quiz/presentation/parts/QuizCard.tsx
@@ -1,4 +1,5 @@
 import { ImageIcon } from "lucide-react";
+import { useState } from "react";
 
 import { ShimmerButton } from "#/components/magicui/shimmer-button";
 import { ShineBorder } from "#/components/magicui/shine-border";
@@ -15,6 +16,7 @@ interface QuizCardProps {
 export function QuizCard({ question }: QuizCardProps) {
 	const selectedChoiceIds = useQuizStore((s) => s.selectedChoiceIds);
 	const submitMutation = useSubmitAnswer();
+	const [imageError, setImageError] = useState(false);
 
 	const handleSubmit = () => {
 		submitMutation.mutate({
@@ -22,6 +24,9 @@ export function QuizCard({ question }: QuizCardProps) {
 			selectedChoiceIds,
 		});
 	};
+
+	const showImage = question.imageUrl && !imageError;
+	const showPlaceholder = !question.videoUrl && !showImage;
 
 	return (
 		<div className="relative">
@@ -46,7 +51,17 @@ export function QuizCard({ question }: QuizCardProps) {
 								data-testid="video-player"
 							/>
 						</div>
-					) : (
+					) : showImage ? (
+						<div className="flex justify-center">
+							<img
+								src={question.imageUrl}
+								alt={question.questionWord}
+								className="w-40 h-40 object-cover rounded-lg"
+								data-testid="image-display"
+								onError={() => setImageError(true)}
+							/>
+						</div>
+					) : showPlaceholder ? (
 						<div className="flex justify-center">
 							<div
 								className="w-40 h-40 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300"
@@ -55,7 +70,7 @@ export function QuizCard({ question }: QuizCardProps) {
 								<ImageIcon className="w-12 h-12 text-gray-400" />
 							</div>
 						</div>
-					)}
+					) : null}
 
 					<ChoiceList choices={question.choices} />
 


### PR DESCRIPTION
## 変更概要

Issue #43 の実装。クイズの問題文に画像を表示できるようにする。

## 変更点

- **`imageResolver.ts` を新規作成**  
  `IMAGE_PROVIDER` 環境変数で `local`（`/images/{key}.jpg`）と `cloudflare-r2` を切り替えられる仕組みを追加。将来的な Cloudflare R2 への移行に備えた設計。

- **`contracts/quiz.ts`**  
  `QuizQuestionSchema` に `imageUrl?: string` フィールドを追加。

- **`quizService.ts`**  
  `imageKey` が設定されている問題に `imageUrl` を解決してレスポンスに含めるよう更新。

- **`QuizCard.tsx`**  
  表示優先度: `videoUrl` → `imageUrl`（ロードエラー時はプレースホルダーにフォールバック） → プレースホルダー

- **テスト**  
  - `imageResolver.test.ts`（5テスト）: プロバイダー切り替えの動作確認  
  - `QuizCard.test.tsx`（16テスト）: 画像表示・エラー時フォールバックの動作確認

- **`docs/test/image.md`**  
  画像機能テストの解説ドキュメントを追加。

## テスト内容

- `npx tsc --noEmit` → 型エラー 0件
- `pnpm build` → ビルド成功
- `pnpm test` → 52テスト全通過

Closes #43