### PR TITLE
feat(quiz): 問題4の選択肢を上から下に流す縦スクロール表示を追加 #32

### DIFF
--- a/src/features/quiz/application/services/quizService.ts
+++ b/src/features/quiz/application/services/quizService.ts
@@ -11,6 +11,7 @@ export interface QuestionForClient {
 	imageUrl?: string
 	videoUrl?: string
 	marqueeMode?: boolean
+	verticalMarqueeMode?: boolean
 	choices: Array<{ id: string; text: string }>
 	total: number
 	index: number
@@ -35,6 +36,7 @@ export async function getQuestionByIndex(
 		...(quiz.imageKey ? { imageUrl: resolveImageUrl(quiz.imageKey) } : {}),
 		...(quiz.videoKey ? { videoUrl: resolveVideoUrl(quiz.videoKey) } : {}),
 		...(quiz.marqueeMode ? { marqueeMode: true } : {}),
+		...(quiz.verticalMarqueeMode ? { verticalMarqueeMode: true } : {}),
 		choices: shuffledChoices,
 		total: allQuizzes.length,
 		index,

--- a/src/features/quiz/contracts/quiz.ts
+++ b/src/features/quiz/contracts/quiz.ts
@@ -12,6 +12,7 @@ export const QuizQuestionSchema = z.object({
 	imageUrl: z.string().optional(),
 	videoUrl: z.string().optional(),
 	marqueeMode: z.boolean().optional(),
+	verticalMarqueeMode: z.boolean().optional(),
 	choices: z.array(ChoiceSchema),
 	total: z.number(),
 	index: z.number(),

--- a/src/features/quiz/domain/entities/quiz.ts
+++ b/src/features/quiz/domain/entities/quiz.ts
@@ -12,6 +12,7 @@ export interface QuizFull {
 	imageKey: string;
 	videoKey?: string;
 	marqueeMode?: boolean;
+	verticalMarqueeMode?: boolean;
 	explanation: string;
 	choices: ChoiceFull[];
 }

--- a/src/features/quiz/infrastructure/data/quizData.ts
+++ b/src/features/quiz/infrastructure/data/quizData.ts
@@ -51,6 +51,8 @@ export const quizzes: QuizFull[] = [
 		questionWord: "むかしばなし",
 		questionVowels: "うあいああい",
 		imageKey: "mukashibanashi",
+		verticalMarqueeMode: true,
+		marqueeMode: true,
 		explanation:
 			"「むかしばなし」の母音は「うあいああい」。同じ母音パターンの「つかいはたし」「ふかいはなし」「くさいかかし」「むかしかがみ」が正解。",
 		choices: [

--- a/src/features/quiz/presentation/parts/QuizCard.tsx
+++ b/src/features/quiz/presentation/parts/QuizCard.tsx
@@ -1,4 +1,4 @@
-import { ImageIcon, MonitorPlay, Type } from "lucide-react";
+import { ArrowDown, ImageIcon, MonitorPlay, Type } from "lucide-react";
 import { useState } from "react";
 
 import { ShimmerButton } from "#/components/magicui/shimmer-button";
@@ -9,23 +9,26 @@ import type { QuizQuestion } from "../../contracts/quiz";
 import { useQuizStore, useSubmitAnswer } from "../hooks/useQuiz";
 import { ChoiceList } from "./ChoiceList";
 import { RomajiMarquee } from "./RomajiMarquee";
+import { RomajiVerticalMarquee } from "./RomajiVerticalMarquee";
 
 interface QuizCardProps {
 	question: QuizQuestion;
 }
 
-type DisplayMode = "marquee" | "image" | "video";
+type DisplayMode = "vertical-marquee" | "marquee" | "image" | "video";
 
 export function QuizCard({ question }: QuizCardProps) {
 	const selectedChoiceIds = useQuizStore((s) => s.selectedChoiceIds);
 	const submitMutation = useSubmitAnswer();
 	const [imageError, setImageError] = useState(false);
 
-	const initialMode: DisplayMode = question.marqueeMode
-		? "marquee"
-		: question.videoUrl
-			? "video"
-			: "image";
+	const initialMode: DisplayMode = question.verticalMarqueeMode
+		? "vertical-marquee"
+		: question.marqueeMode
+			? "marquee"
+			: question.videoUrl
+				? "video"
+				: "image";
 	const [displayMode, setDisplayMode] = useState<DisplayMode>(initialMode);
 
 	const handleSubmit = () => {
@@ -38,8 +41,15 @@ export function QuizCard({ question }: QuizCardProps) {
 	const hasImage = Boolean(question.imageUrl) && !imageError;
 	const hasVideo = Boolean(question.videoUrl);
 	const hasMarquee = Boolean(question.marqueeMode);
+	const hasVerticalMarquee = Boolean(question.verticalMarqueeMode);
 
-	const showToggle = hasMarquee && (hasImage || hasVideo);
+	const availableModes = [
+		hasVerticalMarquee && "vertical-marquee",
+		hasMarquee && "marquee",
+		hasVideo && "video",
+		hasImage && "image",
+	].filter(Boolean) as DisplayMode[];
+	const showToggle = availableModes.length > 1;
 
 	return (
 		<div className="relative">
@@ -57,19 +67,36 @@ export function QuizCard({ question }: QuizCardProps) {
 				<CardContent className="space-y-6">
 					{showToggle && (
 						<div className="flex justify-end gap-2">
-							<button
-								type="button"
-								onClick={() => setDisplayMode("marquee")}
-								className={`flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
-									displayMode === "marquee"
-										? "bg-green-600 text-white"
-										: "bg-gray-200 text-gray-600 hover:bg-gray-300"
-								}`}
-								aria-label="ローマ字スクロール表示"
-							>
-								<Type className="w-3 h-3" />
-								ローマ字
-							</button>
+							{hasVerticalMarquee && (
+								<button
+									type="button"
+									onClick={() => setDisplayMode("vertical-marquee")}
+									className={`flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
+										displayMode === "vertical-marquee"
+											? "bg-green-600 text-white"
+											: "bg-gray-200 text-gray-600 hover:bg-gray-300"
+									}`}
+									aria-label="ローマ字縦スクロール表示"
+								>
+									<ArrowDown className="w-3 h-3" />
+									縦ローマ字
+								</button>
+							)}
+							{hasMarquee && (
+								<button
+									type="button"
+									onClick={() => setDisplayMode("marquee")}
+									className={`flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
+										displayMode === "marquee"
+											? "bg-green-600 text-white"
+											: "bg-gray-200 text-gray-600 hover:bg-gray-300"
+									}`}
+									aria-label="ローマ字横スクロール表示"
+								>
+									<Type className="w-3 h-3" />
+									横ローマ字
+								</button>
+							)}
 							{hasVideo && (
 								<button
 									type="button"
@@ -103,7 +130,12 @@ export function QuizCard({ question }: QuizCardProps) {
 						</div>
 					)}
 
-					{displayMode === "marquee" && hasMarquee ? (
+					{displayMode === "vertical-marquee" && hasVerticalMarquee ? (
+						<RomajiVerticalMarquee
+							questionWord={question.questionWord}
+							choices={question.choices}
+						/>
+					) : displayMode === "marquee" && hasMarquee ? (
 						<RomajiMarquee
 							questionWord={question.questionWord}
 							choices={question.choices}
@@ -127,7 +159,7 @@ export function QuizCard({ question }: QuizCardProps) {
 								onError={() => setImageError(true)}
 							/>
 						</div>
-					) : !hasMarquee && !hasVideo && !hasImage ? (
+					) : !hasVerticalMarquee && !hasMarquee && !hasVideo && !hasImage ? (
 						<div className="flex justify-center">
 							<div
 								className="w-40 h-40 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-300"

--- a/src/features/quiz/presentation/parts/RomajiVerticalMarquee.tsx
+++ b/src/features/quiz/presentation/parts/RomajiVerticalMarquee.tsx
@@ -1,0 +1,47 @@
+import type { Choice } from "../../contracts/quiz";
+import { hiraganaToRomaji } from "../utils/hiraganaToRomaji";
+
+interface RomajiVerticalMarqueeProps {
+	questionWord: string;
+	choices: Choice[];
+}
+
+export function RomajiVerticalMarquee({
+	questionWord,
+	choices,
+}: RomajiVerticalMarqueeProps) {
+	const questionRomaji = hiraganaToRomaji(questionWord);
+	const items = [questionRomaji, ...choices.map((c) => hiraganaToRomaji(c.text))];
+	// 3回繰り返して連続スクロールを実現
+	const repeatedItems = [...items, ...items, ...items];
+
+	return (
+		<div
+			className="w-full h-40 bg-gray-900 rounded-lg overflow-hidden relative"
+			data-testid="romaji-vertical-marquee"
+		>
+			<div
+				className="absolute inset-0 flex flex-col"
+				style={{
+					animation: "vertical-marquee 10s linear infinite",
+				}}
+			>
+				{repeatedItems.map((text, i) => (
+					<p
+						// eslint-disable-next-line react/no-array-index-key
+						key={i}
+						className="text-green-400 font-mono text-lg font-bold tracking-widest whitespace-nowrap px-4 leading-8"
+					>
+						{text}
+					</p>
+				))}
+			</div>
+			<style>{`
+				@keyframes vertical-marquee {
+					0% { transform: translateY(-33.33%); }
+					100% { transform: translateY(0%); }
+				}
+			`}</style>
+		</div>
+	);
+}

--- a/src/features/quiz/presentation/parts/__tests__/QuizCard.test.tsx
+++ b/src/features/quiz/presentation/parts/__tests__/QuizCard.test.tsx
@@ -77,6 +77,21 @@ const questionWithoutMedia: QuizQuestion = {
 	index: 2,
 };
 
+// テスト用の問題データ（verticalMarqueeMode あり）
+const questionWithVerticalMarquee: QuizQuestion = {
+	id: "q4",
+	questionWord: "むかしばなし",
+	imageKey: "mukashibanashi",
+	verticalMarqueeMode: true,
+	marqueeMode: true,
+	choices: [
+		{ id: "q4-c1", text: "つかいはたし" },
+		{ id: "q4-c2", text: "ふかいはなし" },
+	],
+	total: 5,
+	index: 3,
+};
+
 describe("QuizCard", () => {
 	// 各テスト前に Zustand ストアをリセットする
 	// （テスト間で selectedChoiceIds などの状態が残らないようにする）
@@ -193,6 +208,84 @@ describe("QuizCard", () => {
 			// getAllByText で複数マッチを許容しつつ存在確認
 			expect(screen.getAllByText("からだ").length).toBeGreaterThan(0);
 			expect(screen.getAllByText("ながら").length).toBeGreaterThan(0);
+		});
+	});
+
+	describe("縦スクロールローマ字表示（verticalMarqueeMode）", () => {
+		it("verticalMarqueeMode があるとき縦ローマ字マーキーを表示する", () => {
+			renderWithProviders(
+				<QuizCard question={questionWithVerticalMarquee} />,
+			);
+
+			expect(
+				screen.getByTestId("romaji-vertical-marquee"),
+			).toBeInTheDocument();
+		});
+
+		it("verticalMarqueeMode があるとき初期状態では横マーキーを表示しない", () => {
+			renderWithProviders(
+				<QuizCard question={questionWithVerticalMarquee} />,
+			);
+
+			expect(
+				screen.queryByTestId("romaji-marquee"),
+			).not.toBeInTheDocument();
+		});
+
+		it("verticalMarqueeMode があるとき画像プレースホルダーを表示しない", () => {
+			renderWithProviders(
+				<QuizCard question={questionWithVerticalMarquee} />,
+			);
+
+			expect(
+				screen.queryByTestId("image-placeholder"),
+			).not.toBeInTheDocument();
+		});
+
+		it("verticalMarqueeMode と marqueeMode 両方あるとき切り替えボタンが表示される", () => {
+			renderWithProviders(
+				<QuizCard question={questionWithVerticalMarquee} />,
+			);
+
+			expect(
+				screen.getByRole("button", { name: "ローマ字縦スクロール表示" }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: "ローマ字横スクロール表示" }),
+			).toBeInTheDocument();
+		});
+
+		it("横ローマ字ボタンをクリックすると横マーキーに切り替わる", () => {
+			renderWithProviders(
+				<QuizCard question={questionWithVerticalMarquee} />,
+			);
+
+			const horizontalButton = screen.getByRole("button", {
+				name: "ローマ字横スクロール表示",
+			});
+			fireEvent.click(horizontalButton);
+
+			expect(screen.getByTestId("romaji-marquee")).toBeInTheDocument();
+			expect(
+				screen.queryByTestId("romaji-vertical-marquee"),
+			).not.toBeInTheDocument();
+		});
+
+		it("縦ローマ字ボタンをクリックすると縦マーキーに戻る", () => {
+			renderWithProviders(
+				<QuizCard question={questionWithVerticalMarquee} />,
+			);
+
+			fireEvent.click(
+				screen.getByRole("button", { name: "ローマ字横スクロール表示" }),
+			);
+			fireEvent.click(
+				screen.getByRole("button", { name: "ローマ字縦スクロール表示" }),
+			);
+
+			expect(
+				screen.getByTestId("romaji-vertical-marquee"),
+			).toBeInTheDocument();
 		});
 	});
 


### PR DESCRIPTION
## 変更概要

問題4（むかしばなし）で選択肢のローマ字が上から下へ流れる縦スクロール表示を追加。

## 変更点

- `RomajiVerticalMarquee.tsx` を新規作成（上から下へ流れる縦マーキー）
- `QuizCard.tsx` に `vertical-marquee` 表示モードを追加
  - 縦ローマ字・横ローマ字（q3スタイル）の切り替えボタンを表示
- `contracts/quiz.ts`: `verticalMarqueeMode` フィールドを追加
- `domain/entities/quiz.ts`: `verticalMarqueeMode` フィールドを追加
- `quizData.ts`: q4 に `verticalMarqueeMode: true` と `marqueeMode: true` を追加
- `quizService.ts`: `verticalMarqueeMode` をクライアントに送信
- `QuizCard.test.tsx`: 縦マーキー表示・切り替えのテストを追加（6件）

## 動作仕様

- 問題4では初期表示で縦スクロール（上→下）でローマ字が流れる
- トグルボタンで「縦ローマ字」「横ローマ字（q3スタイル）」を切り替え可能
- 画像・動画がある問題ではそれらのボタンも表示される
- 画像がない問題（q5等）は従来通りプレースホルダー表示

## テスト結果

```
Test Files  6 passed (6)
     Tests  58 passed (58)
```

`npx tsc --noEmit` 型エラー 0件、`pnpm build` ビルド成功。

Closes #32