### PR TITLE
docs(design): add design pattern documentation and refactor imageResolver to Strategy pattern

### DIFF
--- a/docs/design/00-basics.md
+++ b/docs/design/00-basics.md
@@ -1,0 +1,84 @@
+# デザインパターン 基礎知識
+
+## デザインパターンとは？
+
+**デザインパターン**とは、ソフトウェア開発でよく遭遇する問題に対する「再利用可能な解法の設計図」です。
+
+1994年に発表された書籍 *Design Patterns: Elements of Reusable Object-Oriented Software*（通称 **GoF本**）で体系化され、23種類のパターンが定義されています。
+
+---
+
+## なぜ使うのか？
+
+| 目的 | 説明 |
+|------|------|
+| **コードの意図を伝える** | 「これはStrategyパターンだ」と言えば構造が伝わる |
+| **変更しやすくする** | パターンは「変化する部分を分離する」ことが多い |
+| **テストしやすくする** | 依存を抽象に向けるため、差し替えが容易になる |
+| **再発明を防ぐ** | 先人が解いた問題を一から考えなくてよい |
+
+---
+
+## GoF の 3 分類
+
+### 生成パターン（Creational）
+オブジェクトの**生成方法**を扱う。生成ロジックを隠蔽することで、コードの柔軟性を高める。
+
+| パターン | 一言説明 |
+|---------|---------|
+| Singleton | インスタンスを1つだけに制限する |
+| **Factory Method** | サブクラスがどのオブジェクトを生成するか決める |
+| Abstract Factory | 関連するオブジェクト群をまとめて生成する |
+| Builder | 複雑なオブジェクトを段階的に組み立てる |
+| Prototype | 既存オブジェクトをコピーして生成する |
+
+### 構造パターン（Structural）
+クラスやオブジェクトの**組み合わせ方**を扱う。
+
+| パターン | 一言説明 |
+|---------|---------|
+| Adapter | 互換性のないインターフェースを変換する |
+| **Facade** | 複雑なサブシステムに簡単な窓口を提供する |
+| Decorator | オブジェクトに機能を動的に追加する |
+| Composite | ツリー構造でオブジェクトを扱う |
+| Proxy | オブジェクトへのアクセスを代理する |
+
+### 振る舞いパターン（Behavioral）
+オブジェクト間の**責任の分担と通信**を扱う。
+
+| パターン | 一言説明 |
+|---------|---------|
+| **Strategy** | アルゴリズムを切り替え可能にする |
+| **Observer** | 状態変化を他のオブジェクトに通知する |
+| **State** | 状態に応じて振る舞いを変える |
+| **Template Method** | 処理の骨格を定め、詳細はサブクラスに委ねる |
+| Command | 操作をオブジェクトとしてカプセル化する |
+| Iterator | コレクションを順に走査する方法を提供する |
+
+---
+
+## 本プロジェクトで使われているパターン
+
+| パターン | 場所 | 分類 |
+|---------|------|------|
+| Repository | `domain/ports/` + `infrastructure/repositories/` | 構造 |
+| Factory | `infrastructure/getRepository.ts` | 生成 |
+| Strategy | `infrastructure/media/imageResolver.ts` | 振る舞い |
+| Facade | `application/services/quizService.ts` | 構造 |
+| State Machine | `presentation/hooks/useQuiz.ts` | 振る舞い |
+| Observer | Zustand の subscription 機構 | 振る舞い |
+
+各パターンの詳細は以下のドキュメントを参照してください。
+
+- [01-repository-pattern.md](./01-repository-pattern.md)
+- [02-strategy-pattern.md](./02-strategy-pattern.md)
+- [03-facade-pattern.md](./03-facade-pattern.md)
+- [04-state-machine-pattern.md](./04-state-machine-pattern.md)
+
+---
+
+## 「パターンは目的ではなく手段」
+
+パターンを使うこと自体が目的になってはいけません。
+「この問題を解決するために、このパターンが適切だ」という判断が大切です。
+無理にパターンを当てはめると、かえって複雑になることもあります。

--- a/docs/design/01-repository-pattern.md
+++ b/docs/design/01-repository-pattern.md
@@ -1,0 +1,112 @@
+# リポジトリパターン（Repository Pattern）
+
+## どのパターンか？
+
+**リポジトリパターン**は、データの保存・取得処理（データアクセスロジック）をビジネスロジックから切り離すための構造パターンです。
+GoFの23パターンには直接含まれませんが、ドメイン駆動設計（DDD）で広く知られるパターンです。
+
+---
+
+## 解決する問題
+
+データソース（JSON、DB、外部API など）の詳細をビジネスロジックが知っていると、データソースが変わるたびにロジックも修正する必要が生じます。
+
+```
+❌ 問題のある設計
+quizService.ts
+  └─ quizData（JSON）を直接参照
+        ↓
+  JSONをDBに変えたい → quizService.ts も修正が必要
+```
+
+```
+✅ リポジトリパターン
+quizService.ts
+  └─ QuizRepository（インターフェース）を参照  ← 抽象に依存
+        ↓
+  JsonQuizRepository が実装           ← 具体は差し替え可能
+  DrizzleQuizRepository が実装（将来）
+```
+
+---
+
+## 本プロジェクトでの実装
+
+### ポート（インターフェース定義）
+`src/features/quiz/domain/ports/quizRepository.ts`
+
+```typescript
+import type { QuizFull } from "../entities/quiz";
+
+export interface QuizRepository {
+  findAllQuestions(): Promise<QuizFull[]>;
+  findFullById(id: string): Promise<QuizFull | null>;
+}
+```
+
+ドメイン層に **「何ができるか（契約）」だけ** を定義します。
+「どうやって実現するか」は一切書きません。
+
+### 具体的な実装（アダプター）
+`src/features/quiz/infrastructure/repositories/jsonQuizRepository.ts`
+
+```typescript
+import type { QuizFull } from "../../domain/entities/quiz";
+import type { QuizRepository } from "../../domain/ports/quizRepository";
+import { quizzes } from "../data/quizData";
+
+export class JsonQuizRepository implements QuizRepository {
+  async findAllQuestions(): Promise<QuizFull[]> {
+    return quizzes;
+  }
+
+  async findFullById(id: string): Promise<QuizFull | null> {
+    return quizzes.find((q) => q.id === id) ?? null;
+  }
+}
+```
+
+インターフェースを `implements` することで、契約を守っていることをコンパイラが保証します。
+
+---
+
+## クラス図
+
+```
+<<interface>>
+QuizRepository
+  + findAllQuestions(): Promise<QuizFull[]>
+  + findFullById(id): Promise<QuizFull | null>
+         ↑ implements
+JsonQuizRepository            DrizzleQuizRepository（将来）
+  - quizData を読み込む        - Turso DB を参照
+```
+
+---
+
+## ヘキサゴナルアーキテクチャとの関係
+
+本プロジェクトはヘキサゴナルアーキテクチャ（別名: ポート&アダプターパターン）を採用しています。
+
+```
+【ドメイン（中心）】
+  QuizRepository インターフェース ← これが「ポート」
+
+【インフラ（外側）】
+  JsonQuizRepository              ← これが「アダプター」
+  DrizzleQuizRepository（将来）   ← これも「アダプター」
+```
+
+ポート（インターフェース）はドメイン層に置き、ドメインはインフラの詳細を知りません。
+インフラ層がドメイン層に向かって依存する（**依存性逆転の原則**）ことで、
+将来 DB に切り替えてもドメインロジックは変更不要になります。
+
+---
+
+## メリット
+
+| メリット | 説明 |
+|---------|------|
+| **テストが簡単** | テスト用の `MockQuizRepository` に差し替えられる |
+| **技術の切り替えが容易** | JSON → DB への変更がビジネスロジックに影響しない |
+| **関心の分離** | ビジネスルールとデータアクセスが混在しない |

--- a/docs/design/02-strategy-pattern.md
+++ b/docs/design/02-strategy-pattern.md
@@ -1,0 +1,146 @@
+# ストラテジーパターン（Strategy Pattern）
+
+## どのパターンか？
+
+**ストラテジーパターン**は、アルゴリズム（処理方法）をオブジェクトとして定義し、実行時に切り替えられるようにする振る舞いパターンです。GoF の23パターンのひとつです。
+
+---
+
+## 解決する問題
+
+「条件によって処理を切り替えたい」というケースで `if` や `switch` を使うと、追加するたびにコードが膨れ上がります。
+
+```typescript
+// ❌ switch に追加し続ける設計
+switch (provider) {
+  case "cloudflare-r2":
+    return `https://.../${key}.jpg`;
+  case "aws-s3":                    // ← 追加のたびにここを変える
+    return `https://s3.../${key}`;
+  case "local":
+  default:
+    return `/images/${key}.jpg`;
+}
+```
+
+新しいプロバイダーを追加するたびに既存コードを修正する必要があり、**開放閉鎖の原則（OCP）** に違反します。
+
+---
+
+## 本プロジェクトでの実装
+
+`src/features/quiz/infrastructure/media/imageResolver.ts` をリファクタリングしました。
+
+### リファクタリング前（switch 版）
+
+```typescript
+export function resolveImageUrl(key: string): string {
+  const provider = getImageProvider();
+  switch (provider) {
+    case "cloudflare-r2":
+      return `https://${process.env.CLOUDFLARE_R2_PUBLIC_URL}/${key}.jpg`;
+    case "local":
+    default:
+      return `/images/${key}.jpg`;
+  }
+}
+```
+
+### リファクタリング後（Strategy パターン版）
+
+```typescript
+// Strategy インターフェース：「どう解決するか」の契約
+interface ImageStrategy {
+  resolve(key: string): string;
+}
+
+// 具体的なストラテジー① ローカルファイルを使う
+class LocalImageStrategy implements ImageStrategy {
+  resolve(key: string): string {
+    return `/images/${key}.jpg`;
+  }
+}
+
+// 具体的なストラテジー② Cloudflare R2 を使う
+class CloudflareR2ImageStrategy implements ImageStrategy {
+  resolve(key: string): string {
+    return `https://${process.env.CLOUDFLARE_R2_PUBLIC_URL}/${key}.jpg`;
+  }
+}
+
+// ストラテジーの登録テーブル（新しいプロバイダーはここに追加するだけ）
+const imageStrategies: Record<ImageProvider, ImageStrategy> = {
+  local: new LocalImageStrategy(),
+  "cloudflare-r2": new CloudflareR2ImageStrategy(),
+};
+
+// 公開 API は変わらない
+export function resolveImageUrl(key: string): string {
+  const provider = getImageProvider();
+  return imageStrategies[provider].resolve(key);
+}
+```
+
+---
+
+## クラス図
+
+```
+<<interface>>
+ImageStrategy
+  + resolve(key: string): string
+         ↑ implements
+LocalImageStrategy          CloudflareR2ImageStrategy
+  resolve() → "/images/..." resolve() → "https://..."
+
+imageStrategies: Record<ImageProvider, ImageStrategy>
+  { local: LocalImageStrategy, "cloudflare-r2": CloudflareR2ImageStrategy }
+```
+
+---
+
+## 新しいプロバイダーの追加方法
+
+AWS S3 を追加したい場合、**既存コードを一切変更せず**に追加できます。
+
+```typescript
+// 1. 新しいストラテジークラスを追加
+class AwsS3ImageStrategy implements ImageStrategy {
+  resolve(key: string): string {
+    return `https://${process.env.AWS_S3_BUCKET}.s3.amazonaws.com/${key}.jpg`;
+  }
+}
+
+// 2. 型に追加
+export type ImageProvider = "local" | "cloudflare-r2" | "aws-s3";
+
+// 3. テーブルに追加
+const imageStrategies: Record<ImageProvider, ImageStrategy> = {
+  local: new LocalImageStrategy(),
+  "cloudflare-r2": new CloudflareR2ImageStrategy(),
+  "aws-s3": new AwsS3ImageStrategy(),   // ← ここだけ変更
+};
+```
+
+既存の `LocalImageStrategy` や `CloudflareR2ImageStrategy` は一切触らなくて済みます。
+
+---
+
+## 関連パターンとの比較
+
+| パターン | 特徴 | 使いどころ |
+|---------|------|-----------|
+| Strategy | アルゴリズムをオブジェクトとして分離 | 実行時に切り替えたい |
+| Template Method | 骨格を定め、詳細をサブクラスに委ねる | 処理の流れは固定したい |
+| Factory | オブジェクト生成を分離 | 生成ロジックを隠したい |
+
+---
+
+## メリット
+
+| メリット | 説明 |
+|---------|------|
+| **開放閉鎖の原則** | 追加は「開放」、既存コードの変更は「閉鎖」 |
+| **単一責任の原則** | 各ストラテジーは1つの実装責任だけ持つ |
+| **テストが容易** | 各ストラテジーを単独でテストできる |
+| **切り替えが安全** | 型システムが全プロバイダーの実装を強制する |

--- a/docs/design/03-facade-pattern.md
+++ b/docs/design/03-facade-pattern.md
@@ -1,0 +1,132 @@
+# ファサードパターン（Facade Pattern）
+
+## どのパターンか？
+
+**ファサードパターン**は、複数のサブシステムへのアクセスをまとめた「窓口（facade）」を提供する構造パターンです。GoF の23パターンのひとつです。
+
+Facade とはフランス語で「建物の正面（顔）」を意味します。建物の内部構造を隠し、外からは正面だけを見せるイメージです。
+
+---
+
+## 解決する問題
+
+複雑な処理をそのまま呼び出し側に公開すると、呼び出し側がサブシステムの詳細を知る必要が生じます。
+
+```
+❌ 呼び出し側が複雑さを知る設計
+API ルートが直接:
+  1. getRepository() を呼んで
+  2. repo.findAllQuestions() を呼んで
+  3. インデックスで絞り込んで
+  4. resolveImageUrl() を呼んで
+  5. 選択肢をシャッフルして
+  6. DTOに詰めて返す
+  → 全部 API ルートに書くと責任過多になる
+```
+
+```
+✅ ファサードパターン
+API ルートは:
+  getQuestionByIndex(index) を呼ぶだけ  ← 1行で済む
+                  ↓
+  quizService.ts が内部の複雑さを隠蔽
+```
+
+---
+
+## 本プロジェクトでの実装
+
+`src/features/quiz/application/services/quizService.ts` がファサードの役割を担っています。
+
+### ファサード（quizService.ts）
+
+```typescript
+export async function getQuestionByIndex(
+  index: number,
+): Promise<QuestionForClient | null> {
+  // 1. リポジトリを取得（Factory パターンを利用）
+  const repo = getRepository();
+
+  // 2. データ取得
+  const allQuizzes = await repo.findAllQuestions();
+  const quiz = allQuizzes[index];
+  if (!quiz) return null;
+
+  // 3. 選択肢をシャッフル（毎回ランダムな順序）
+  const shuffledChoices = quiz.choices
+    .map((c) => ({ id: c.id, text: c.text }))
+    .sort(() => Math.random() - 0.5);
+
+  // 4. メディアURLを解決（Strategy パターンを利用）
+  return {
+    id: quiz.id,
+    questionWord: quiz.questionWord,
+    imageKey: quiz.imageKey,
+    ...(quiz.imageKey ? { imageUrl: resolveImageUrl(quiz.imageKey) } : {}),
+    ...(quiz.videoKey ? { videoUrl: resolveVideoUrl(quiz.videoKey) } : {}),
+    choices: shuffledChoices,
+    total: allQuizzes.length,
+    index,
+  };
+}
+```
+
+### 呼び出し側（API ルート）
+
+`app/routes/api/quiz/next.ts` は 1 行呼ぶだけで済みます。
+
+```typescript
+const question = await getQuestionByIndex(index);
+```
+
+内部で Repository、Strategy、シャッフルロジックなどを呼び出していることを呼び出し側は知りません。
+
+---
+
+## 依存関係図
+
+```
+[APIルート]
+    │ getQuestionByIndex(index) を呼ぶだけ
+    ▼
+[quizService.ts]  ← ファサード（窓口）
+    │
+    ├─── getRepository() → JsonQuizRepository
+    │         （Repository パターン）
+    │
+    ├─── resolveImageUrl() → ImageStrategy
+    │         （Strategy パターン）
+    │
+    ├─── resolveVideoUrl() → VideoStrategy
+    │         （Strategy パターン）
+    │
+    └─── judgeAnswer() → 純粋関数
+              （Domain Logic）
+```
+
+---
+
+## なぜ application/ 層に置くのか？
+
+```
+domain/      → ビジネスルール（純粋関数、型定義）
+application/ → ユースケースの調整役 ← ここがファサード
+infrastructure/ → 外部アクセス（DB, API, JSON）
+presentation/ → UI
+```
+
+ファサードは「ユースケースを実行するためにサブシステムを調整する」役割なので、
+`application/` 層に配置するのが適切です。
+また、TanStack Start や Hono などのフレームワークには依存しないため、
+将来フレームワークを変えても `quizService.ts` はそのまま使えます。
+
+---
+
+## メリット
+
+| メリット | 説明 |
+|---------|------|
+| **シンプルな呼び出し** | 呼び出し側は複雑な処理を知らなくてよい |
+| **疎結合** | サブシステムの実装変更が呼び出し側に影響しない |
+| **テストが容易** | ファサードをモックすれば API ルートのテストが書ける |
+| **フレームワーク非依存** | quizService.ts 自体はフレームワークを知らない |

--- a/docs/design/04-state-machine-pattern.md
+++ b/docs/design/04-state-machine-pattern.md
@@ -1,0 +1,165 @@
+# ステートマシンパターン（State Machine Pattern）
+
+## どのパターンか？
+
+**ステートマシン（状態機械）**は、オブジェクトが**有限個の状態**を持ち、
+定義されたイベントによって状態が遷移する設計パターンです。
+
+GoF パターンの **State パターン**がオブジェクト指向的な実装形式ですが、
+本プロジェクトでは Zustand の状態管理として関数型スタイルで実現しています。
+
+---
+
+## 解決する問題
+
+クイズのフローを単純な `if/else` で管理すると、すぐに複雑になります。
+
+```typescript
+// ❌ if/else が増え続ける設計
+if (hasSubmitted && hasNextQuestion) {
+  showNextButton();
+} else if (hasSubmitted && !hasNextQuestion) {
+  showFinalScore();
+} else if (!hasSubmitted && isLoading) {
+  showLoading();
+} else {
+  showQuizCard();
+}
+```
+
+状態が増えるとすべての `if` を確認・修正する必要があり、バグの温床になります。
+
+---
+
+## 本プロジェクトでの実装
+
+### 状態遷移図
+
+```
+        ┌─────────────────────────────────────┐
+        │                                     │
+        ▼                                     │
+ ┌─────────────┐  submitAnswer  ┌──────────┐  │ reset
+ │  answering  │ ────────────▶  │  result  │  │
+ └─────────────┘                └──────────┘  │
+                                    │ nextQuestion (最後の問題でなければ answering へ)
+                                    │ nextQuestion (最後の問題なら finished へ)
+                                    ▼
+                              ┌──────────┐
+                              │ finished │ ─────────────────────▶ (reset で answering へ)
+                              └──────────┘
+```
+
+### 状態定義
+`src/features/quiz/presentation/hooks/useQuiz.ts`
+
+```typescript
+phase: "answering" | "result" | "finished"
+```
+
+3つの状態しか存在しないことを型で表現しています。
+`"some-other-state"` のような不正な状態をコンパイル時に防げます。
+
+### 状態遷移アクション
+
+```typescript
+// answering → result（回答送信後）
+setSubmitResult: (result) =>
+  set((state) => ({
+    submitResult: result,
+    phase: "result",                    // ← 状態遷移
+    results: [...state.results, { isCorrect: result.isCorrect }],
+  })),
+
+// result → answering または result → finished（次の問題へ）
+nextQuestion: (total) =>
+  set((state) => {
+    const nextIndex = state.currentQuestionIndex + 1;
+    if (nextIndex >= total) {
+      return { phase: "finished", ... }; // ← finished へ遷移
+    }
+    return { phase: "answering", ... };  // ← answering へ遷移
+  }),
+
+// finished → answering（リセット）
+reset: () =>
+  set({ phase: "answering", ... }),
+```
+
+### UI での利用（QuizPage.tsx）
+
+```typescript
+// phase に応じてレンダリング内容を切り替える
+if (phase === "finished") {
+  return <FinalResult ... />;
+}
+
+return (
+  <>
+    {phase === "answering" && <QuizCard ... />}
+    {phase === "result" && <ResultDisplay ... />}
+  </>
+);
+```
+
+UI はステートマシンの**現在の状態を観察**するだけで、
+どの状態遷移が起きたかを気にする必要がありません。
+
+---
+
+## GoF の State パターンとの比較
+
+### GoF の State パターン（オブジェクト指向）
+
+```typescript
+// 状態をクラスで表現
+interface QuizState {
+  submitAnswer(context: QuizContext): void;
+  nextQuestion(context: QuizContext): void;
+}
+
+class AnsweringState implements QuizState {
+  submitAnswer(context: QuizContext) {
+    context.setState(new ResultState());
+  }
+  nextQuestion() { /* 無効 */ }
+}
+
+class ResultState implements QuizState {
+  nextQuestion(context: QuizContext) {
+    context.setState(new AnsweringState());
+  }
+  submitAnswer() { /* 無効 */ }
+}
+```
+
+### 本プロジェクトの実装（関数型）
+
+Zustand を使った本プロジェクトでは、状態をクラスではなく
+**型付き文字列リテラル + 純粋関数**で表現しています。
+
+```typescript
+// 状態は型で表現
+phase: "answering" | "result" | "finished"
+
+// 遷移は純粋関数で表現
+nextQuestion: (total) => set((state) => {
+  return nextIndex >= total
+    ? { phase: "finished" }
+    : { phase: "answering" };
+})
+```
+
+どちらも本質的には同じステートマシンですが、
+関数型スタイルの方がシンプルで、React のエコシステムとも相性が良いです。
+
+---
+
+## メリット
+
+| メリット | 説明 |
+|---------|------|
+| **不正状態の排除** | TypeScript 型が存在しない状態を防ぐ |
+| **遷移の明確化** | どのアクションでどの状態に移るかが一目でわかる |
+| **UI のシンプル化** | UI は現在の状態を参照するだけでよい |
+| **バグの早期発見** | 不正な状態遷移がコンパイルエラーになる |

--- a/src/features/quiz/infrastructure/media/imageResolver.ts
+++ b/src/features/quiz/infrastructure/media/imageResolver.ts
@@ -1,16 +1,35 @@
 export type ImageProvider = "local" | "cloudflare-r2";
 
+// Strategy インターフェース
+interface ImageStrategy {
+	resolve(key: string): string;
+}
+
+// 具体的なストラテジー: ローカル
+class LocalImageStrategy implements ImageStrategy {
+	resolve(key: string): string {
+		return `/images/${key}.jpg`;
+	}
+}
+
+// 具体的なストラテジー: Cloudflare R2
+class CloudflareR2ImageStrategy implements ImageStrategy {
+	resolve(key: string): string {
+		return `https://${process.env.CLOUDFLARE_R2_PUBLIC_URL}/${key}.jpg`;
+	}
+}
+
+// ストラテジーの登録テーブル（新しいプロバイダーはここに追加するだけ）
+const imageStrategies: Record<ImageProvider, ImageStrategy> = {
+	local: new LocalImageStrategy(),
+	"cloudflare-r2": new CloudflareR2ImageStrategy(),
+};
+
 function getImageProvider(): ImageProvider {
 	return (process.env.IMAGE_PROVIDER as ImageProvider) ?? "local";
 }
 
 export function resolveImageUrl(key: string): string {
 	const provider = getImageProvider();
-	switch (provider) {
-		case "cloudflare-r2":
-			return `https://${process.env.CLOUDFLARE_R2_PUBLIC_URL}/${key}.jpg`;
-		case "local":
-		default:
-			return `/images/${key}.jpg`;
-	}
+	return imageStrategies[provider].resolve(key);
 }


### PR DESCRIPTION
## 概要

Issue #52 に対応。デザインパターンの解説ドキュメントを `docs/design/` に追加し、
`imageResolver.ts` を明示的なストラテジーパターンにリファクタリングしました。

## 変更点

### リファクタリング（1 箇所）

- `src/features/quiz/infrastructure/media/imageResolver.ts`
  - `switch` 文を **ストラテジーパターン** に書き換え
  - `ImageStrategy` インターフェースを定義
  - `LocalImageStrategy`、`CloudflareR2ImageStrategy` を具体クラスとして分離
  - 新しいプロバイダー追加時に既存クラスを変更せず登録テーブルに追加するだけでよくなった

### 追加ドキュメント（docs/design/）

| ファイル | 内容 |
|---------|------|
| `00-basics.md` | GoF デザインパターン基礎知識（3分類 + 一覧表） |
| `01-repository-pattern.md` | リポジトリパターン（QuizRepository の実装例） |
| `02-strategy-pattern.md` | ストラテジーパターン（リファクタリング前後の比較付き） |
| `03-facade-pattern.md` | ファサードパターン（quizService.ts の役割解説） |
| `04-state-machine-pattern.md` | ステートマシンパターン（クイズフェーズ管理の解説） |

## テスト

- `npx tsc --noEmit` → 型エラー 0件

Closes #52