### PR TITLE
fix(media): guard against invalid IMAGE_PROVIDER in imageResolver

### DIFF
--- a/src/features/quiz/infrastructure/media/imageResolver.ts
+++ b/src/features/quiz/infrastructure/media/imageResolver.ts
@@ -26,7 +26,11 @@ const imageStrategies: Record<ImageProvider, ImageStrategy> = {
 };
 
 function getImageProvider(): ImageProvider {
-	return (process.env.IMAGE_PROVIDER as ImageProvider) ?? "local";
+	const env = process.env.IMAGE_PROVIDER;
+	if (env && env in imageStrategies) {
+		return env as ImageProvider;
+	}
+	return "local";
 }
 
 export function resolveImageUrl(key: string): string {


### PR DESCRIPTION
## 概要

PR #56 のリファクタリングで発生したリグレッションを修正します。

## 問題

`IMAGE_PROVIDER` 環境変数にタイプミスや未定義の値が設定されている場合：

| | 旧 switch 版 | PR #56 後（修正前） |
|---|---|---|
| `IMAGE_PROVIDER="local"` | ✅ 動作 | ✅ 動作 |
| `IMAGE_PROVIDER="typo"` | ✅ `default:` でローカルにフォールバック | ❌ `imageStrategies["typo"]` が `undefined` → `.resolve()` で実行時クラッシュ |

## 修正内容

`getImageProvider()` に `env in imageStrategies` チェックを追加：

```typescript
// 修正前
function getImageProvider(): ImageProvider {
  return (process.env.IMAGE_PROVIDER as ImageProvider) ?? "local";
}

// 修正後
function getImageProvider(): ImageProvider {
  const env = process.env.IMAGE_PROVIDER;
  if (env && env in imageStrategies) {
    return env as ImageProvider;
  }
  return "local";  // 不正な値はローカルにフォールバック
}
```

- `imageStrategies` テーブルに登録済みのプロバイダーのみ有効
- 未登録・不正な値は `"local"` にフォールバック（旧 `switch default:` と同等）
- 新プロバイダーをテーブルに追加すれば自動的にバリデーション対象に含まれる

## テスト

- `npx tsc --noEmit` → 型エラー 0件