### PR TITLE
docs(db): DB設計解説ドキュメントを追加 #61

### DIFF
--- a/docs/db/00-basics.md
+++ b/docs/db/00-basics.md
@@ -1,0 +1,140 @@
+# DB 基礎用語解説
+
+ラップ韻クイズのデータベース設計を学ぶ前に、必要な基礎用語を整理する。
+
+---
+
+## テーブル（Table）
+
+データを格納する表。行（Row）と列（Column）で構成される。
+
+```
+users テーブルのイメージ:
+
+| id | name   | email              | role    |
+|----|--------|--------------------|---------|
+|  1 | 山田太郎 | yamada@example.com | admin   |
+|  2 | 鈴木花子 | suzuki@example.com | general |
+```
+
+---
+
+## 主キー（Primary Key / PK）
+
+テーブル内で各行を一意に識別する列。重複不可・NULL不可。
+
+```sql
+-- id が主キー
+CREATE TABLE users (
+  id   INTEGER PRIMARY KEY,  -- ← ここが主キー
+  name TEXT NOT NULL
+);
+```
+
+---
+
+## 外部キー（Foreign Key / FK）
+
+別のテーブルの主キーを参照する列。テーブル間の関係を表現する。
+
+```sql
+-- quizzes.created_by は users.id を参照する
+CREATE TABLE quizzes (
+  id         INTEGER PRIMARY KEY,
+  question   TEXT NOT NULL,
+  created_by INTEGER REFERENCES users(id)  -- ← 外部キー
+);
+```
+
+---
+
+## インデックス（Index）
+
+検索を高速化するためのデータ構造。本のページの「索引」に相当する。
+
+```sql
+-- choices.quiz_id を頻繁に検索するのでインデックスを張る
+CREATE INDEX idx_choices_quiz_id ON choices(quiz_id);
+```
+
+---
+
+## NULL と NOT NULL
+
+| 制約       | 意味                       |
+|------------|----------------------------|
+| `NOT NULL` | 必ず値が入る               |
+| `NULL`     | 値が未設定でも OK          |
+
+---
+
+## UNIQUE 制約
+
+列の値が重複しないことを保証する。
+
+```sql
+-- メールアドレスは重複不可
+email TEXT UNIQUE NOT NULL
+```
+
+---
+
+## デフォルト値（DEFAULT）
+
+INSERT 時に値を省略した場合に使われる値。
+
+```sql
+created_at INTEGER NOT NULL DEFAULT (unixepoch())
+-- ← 省略すると現在時刻が入る
+```
+
+---
+
+## トランザクション（Transaction）
+
+「全部成功 or 全部失敗」を保証する処理のまとまり。
+
+```sql
+BEGIN;
+  INSERT INTO quizzes ...;
+  INSERT INTO choices ...;  -- ← ここで失敗したら quizzes の INSERT も取り消される
+COMMIT;
+```
+
+---
+
+## CRUD
+
+データベース操作の4種類。
+
+| 操作   | SQL       | 意味       |
+|--------|-----------|------------|
+| Create | `INSERT`  | データを追加 |
+| Read   | `SELECT`  | データを取得 |
+| Update | `UPDATE`  | データを更新 |
+| Delete | `DELETE`  | データを削除 |
+
+---
+
+## 正規化（Normalization）
+
+データの重複を排除し、一貫性を保つための設計手法。詳しくは [01-table-design.md](./01-table-design.md) で解説する。
+
+---
+
+## 冗長性（Redundancy）
+
+同じデータが複数箇所に存在する状態。
+冗長性が高い → 更新漏れのリスクが高い。
+冗長性が低い → 正規化されている。
+
+---
+
+## N+1問題
+
+リストを取得した後、各要素に対して個別にクエリを発行してしまうパフォーマンス問題。
+詳しくは [05-drizzle-orm.md](./05-drizzle-orm.md) で解説する。
+
+---
+
+次: [01-table-design.md — テーブル設計と正規化](./01-table-design.md)

--- a/docs/db/01-table-design.md
+++ b/docs/db/01-table-design.md
@@ -1,0 +1,178 @@
+# テーブル設計と正規化
+
+ラップ韻クイズに必要なデータを「非正規化」と「正規化」の2パターンで比較する。
+
+---
+
+## 管理するデータの整理
+
+まずアプリが扱うデータを洗い出す。
+
+| データ         | 内容                                         |
+|----------------|----------------------------------------------|
+| ユーザー       | 一般ユーザー / 管理者ユーザー                |
+| クイズ問題     | 問題文、母音、画像キー、解説、投稿者         |
+| 選択肢         | テキスト、母音、正解フラグ、表示順、所属問題 |
+
+---
+
+## パターン①: 非正規化（1テーブルにすべてまとめる）
+
+すべてのデータを `quizzes` テーブル1つに詰め込む設計。
+
+```sql
+CREATE TABLE quizzes (
+  id                   TEXT PRIMARY KEY,         -- 問題ID
+  question_word        TEXT NOT NULL,            -- 問題文（例: とら）
+  question_vowels      TEXT NOT NULL,            -- 問題の母音（例: おあ）
+  image_key            TEXT NOT NULL,            -- 画像キー（例: tora）
+  explanation          TEXT NOT NULL,            -- 解説文
+  -- 投稿者情報（users テーブルなし）
+  created_by_user_id   TEXT NOT NULL,
+  created_by_user_name TEXT NOT NULL,            -- ← 冗長！
+  created_by_user_role TEXT NOT NULL,            -- ← 冗長！
+  -- 選択肢をカラムとして並べる
+  choice_1_id          TEXT NOT NULL,
+  choice_1_text        TEXT NOT NULL,
+  choice_1_vowels      TEXT NOT NULL,
+  choice_1_is_correct  INTEGER NOT NULL,         -- 0 or 1
+  choice_2_id          TEXT NOT NULL,
+  choice_2_text        TEXT NOT NULL,
+  choice_2_vowels      TEXT NOT NULL,
+  choice_2_is_correct  INTEGER NOT NULL,
+  choice_3_id          TEXT NOT NULL,
+  choice_3_text        TEXT NOT NULL,
+  choice_3_vowels      TEXT NOT NULL,
+  choice_3_is_correct  INTEGER NOT NULL,
+  choice_4_id          TEXT NOT NULL,
+  choice_4_text        TEXT NOT NULL,
+  choice_4_vowels      TEXT NOT NULL,
+  choice_4_is_correct  INTEGER NOT NULL
+);
+```
+
+**データ例**:
+
+| id | question_word | created_by_user_name | created_by_user_role | choice_1_text | choice_2_text | ... |
+|----|--------------|----------------------|----------------------|--------------|--------------|-----|
+| q1 | とら         | 山田太郎             | admin                | おか          | ぶた          | ... |
+| q2 | くるま       | 山田太郎             | admin                | つくば        | さくら        | ... |
+
+### 非正規化の問題点
+
+**1. 更新異常（Update Anomaly）**
+
+山田太郎の名前を「山田一郎」に変更するとき → **全クイズの行を更新しなければならない**。
+更新漏れが発生するとデータの一貫性が壊れる。
+
+**2. 挿入異常（Insert Anomaly）**
+
+新しい管理者ユーザーを登録するには、必ずクイズも同時に作成しなければならない
+（`created_by_user_*` カラムはクイズがないと存在できない）。
+
+**3. 削除異常（Delete Anomaly）**
+
+あるユーザーが作成した最後のクイズを削除すると、そのユーザーの情報も消えてしまう。
+
+**4. 選択肢が4択固定になる**
+
+5択にしたいときは `choice_5_*` カラムを追加する必要がある（ALTER TABLE が必要）。
+問題によって選択肢数が変わる要件に対応できない。
+
+---
+
+## パターン②: 正規化（3テーブルに分割）
+
+データを意味のまとまりごとに分割し、外部キーで関係を持たせる設計。
+
+### users テーブル
+
+```sql
+CREATE TABLE users (
+  id         TEXT PRIMARY KEY,
+  name       TEXT NOT NULL,
+  email      TEXT UNIQUE NOT NULL,
+  role       TEXT NOT NULL CHECK (role IN ('general', 'admin')),
+  created_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+```
+
+### quizzes テーブル
+
+```sql
+CREATE TABLE quizzes (
+  id              TEXT PRIMARY KEY,
+  question_word   TEXT NOT NULL,
+  question_vowels TEXT NOT NULL,
+  image_key       TEXT NOT NULL,
+  explanation     TEXT NOT NULL,
+  created_by      TEXT NOT NULL REFERENCES users(id),  -- ← 外部キー
+  created_at      INTEGER NOT NULL DEFAULT (unixepoch())
+);
+```
+
+### choices テーブル
+
+```sql
+CREATE TABLE choices (
+  id          TEXT PRIMARY KEY,
+  quiz_id     TEXT NOT NULL REFERENCES quizzes(id),  -- ← 外部キー
+  text        TEXT NOT NULL,
+  vowels      TEXT NOT NULL,
+  is_correct  INTEGER NOT NULL CHECK (is_correct IN (0, 1)),
+  order_index INTEGER NOT NULL DEFAULT 0  -- 表示順
+);
+```
+
+**データ例**:
+
+```
+users:
+| id     | name   | role  |
+|--------|--------|-------|
+| user-1 | 山田太郎 | admin |
+
+quizzes:
+| id | question_word | created_by |
+|----|--------------|------------|
+| q1 | とら         | user-1     |
+| q2 | くるま       | user-1     |
+
+choices:
+| id     | quiz_id | text   | vowels | is_correct | order_index |
+|--------|---------|--------|--------|------------|-------------|
+| q1-c1  | q1      | おか   | おあ   | 1          | 0           |
+| q1-c2  | q1      | ぶた   | うあ   | 0          | 1           |
+| q1-c3  | q1      | ふぐ   | うう   | 0          | 2           |
+| q1-c4  | q1      | さる   | あう   | 0          | 3           |
+| q2-c1  | q2      | つくば | ううあ | 1          | 0           |
+...
+```
+
+---
+
+## 比較まとめ
+
+| 観点               | 非正規化                     | 正規化（3テーブル）         |
+|--------------------|------------------------------|-----------------------------|
+| 更新の一貫性       | ❌ 重複データの更新漏れリスク | ✅ 1箇所を更新すれば済む     |
+| 選択肢数の柔軟性   | ❌ カラム数を変えなければならない | ✅ 行を追加するだけ          |
+| クエリの複雑さ     | ✅ SELECT が単純              | ⚠️ JOIN が必要              |
+| ユーザー管理       | ❌ ユーザーテーブルがない     | ✅ ユーザーを独立管理できる  |
+| 将来の拡張         | ❌ スキーマ変更が頻発         | ✅ テーブルを追加しやすい    |
+
+---
+
+## 正規化の第何形式か？
+
+今回の設計は **第3正規形（3NF）** を満たしている。
+
+| 形式       | 条件                                           |
+|------------|------------------------------------------------|
+| 第1正規形  | 繰り返しグループを排除（選択肢を別テーブルへ） |
+| 第2正規形  | 部分関数従属を排除（複合キーがないので自動的に満たす） |
+| 第3正規形  | 推移関数従属を排除（ユーザー名をクイズに直接持たない） |
+
+---
+
+次: [02-relationships.md — リレーションシップ](./02-relationships.md)

--- a/docs/db/02-relationships.md
+++ b/docs/db/02-relationships.md
@@ -1,0 +1,152 @@
+# リレーションシップ解説
+
+テーブル間の関係（リレーションシップ）を図と SQL で解説する。
+
+---
+
+## ER図（Entity-Relationship Diagram）
+
+```
+users                    quizzes                  choices
+┌──────────────┐         ┌──────────────────┐     ┌──────────────────┐
+│ id (PK)      │         │ id (PK)          │     │ id (PK)          │
+│ name         │◄────────│ created_by (FK)  │◄────│ quiz_id (FK)     │
+│ email        │  1対多  │ question_word    │1対多│ text             │
+│ role         │         │ question_vowels  │     │ vowels           │
+│ created_at   │         │ image_key        │     │ is_correct       │
+└──────────────┘         │ explanation      │     │ order_index      │
+                         │ created_at       │     └──────────────────┘
+                         └──────────────────┘
+```
+
+---
+
+## 1対多（One-to-Many）の関係
+
+### users と quizzes: 1対多
+
+「1人のユーザーが複数のクイズを投稿できる」
+
+```
+user-1 (山田太郎) ──┬── q1 (とら)
+                    ├── q2 (くるま)
+                    └── q3 (ひかり)
+
+user-2 (佐藤次郎) ──── q4 (なみだ)
+```
+
+**SQL での表現**:
+
+```sql
+-- 山田太郎が投稿したクイズを取得
+SELECT quizzes.*
+FROM quizzes
+JOIN users ON quizzes.created_by = users.id
+WHERE users.name = '山田太郎';
+```
+
+### quizzes と choices: 1対多
+
+「1つのクイズが複数の選択肢を持つ」
+
+```
+q1 (とら) ──┬── q1-c1 (おか)
+            ├── q1-c2 (ぶた)
+            ├── q1-c3 (ふぐ)
+            └── q1-c4 (さる)
+```
+
+**SQL での表現**:
+
+```sql
+-- q1 の全選択肢を取得（表示順に並べる）
+SELECT *
+FROM choices
+WHERE quiz_id = 'q1'
+ORDER BY order_index;
+```
+
+---
+
+## 参照整合性（Referential Integrity）
+
+外部キーが指す先のデータが必ず存在することを保証する仕組み。
+
+### 違反の例
+
+```sql
+-- ユーザー user-999 は存在しない
+INSERT INTO quizzes (id, created_by, ...)
+VALUES ('q10', 'user-999', ...);  -- ← 外部キー制約違反！
+```
+
+Turso (libSQL) は SQLite ベースなので、外部キー制約を有効にするために設定が必要:
+
+```sql
+PRAGMA foreign_keys = ON;
+```
+
+Drizzle ORM では接続時に自動的に設定できる（詳細は [05-drizzle-orm.md](./05-drizzle-orm.md)）。
+
+---
+
+## CASCADE（連鎖）オプション
+
+親レコードを削除したとき、子レコードをどう扱うかを指定できる。
+
+```sql
+CREATE TABLE choices (
+  id      TEXT PRIMARY KEY,
+  quiz_id TEXT NOT NULL REFERENCES quizzes(id) ON DELETE CASCADE
+  --                                            ↑ クイズを削除すると選択肢も自動削除
+);
+```
+
+| オプション        | 意味                               |
+|-------------------|------------------------------------|
+| `ON DELETE CASCADE` | 親を削除すると子も削除される       |
+| `ON DELETE RESTRICT` | 子が存在する場合、親を削除できない |
+| `ON DELETE SET NULL` | 親を削除すると子の FK が NULL になる |
+
+今回の設計:
+- `quizzes` 削除 → `choices` も CASCADE で削除 ✅（クイズなし選択肢は不要）
+- `users` 削除 → `quizzes` は RESTRICT（ユーザー削除前にクイズを移管/削除する） ✅
+
+---
+
+## 多対多（Many-to-Many）が必要になるケース
+
+現在の設計では必要ないが、将来「ユーザーが回答履歴を持つ」機能を追加する場合、
+**users と quizzes は多対多の関係**になる。
+
+```
+user_quiz_answers (中間テーブル)
+┌──────────────────────────┐
+│ id (PK)                  │
+│ user_id (FK → users.id)  │
+│ quiz_id (FK → quizzes.id)│
+│ is_correct               │
+│ answered_at              │
+└──────────────────────────┘
+```
+
+```
+user-1 ──── q1 (正解)
+user-1 ──── q2 (不正解)
+user-2 ──── q1 (不正解)
+user-2 ──── q3 (正解)
+```
+
+---
+
+## リレーションシップのまとめ
+
+| 関係                         | 種類   | 実装方法                     |
+|------------------------------|--------|------------------------------|
+| users → quizzes              | 1対多  | `quizzes.created_by` FK      |
+| quizzes → choices            | 1対多  | `choices.quiz_id` FK         |
+| users → quizzes（回答履歴）  | 多対多 | 中間テーブル `user_quiz_answers` |
+
+---
+
+次: [03-schema-design.md — スキーマ設計](./03-schema-design.md)

--- a/docs/db/03-schema-design.md
+++ b/docs/db/03-schema-design.md
@@ -1,0 +1,168 @@
+# スキーマ設計（正規化・冗長性を意識）
+
+正規化と冗長性のバランスを取った、このアプリの最終スキーマを定義する。
+
+---
+
+## 設計方針
+
+1. **第3正規形（3NF）を基本とする** — データの重複を排除
+2. **必要な冗長性は許容する** — JOINが多すぎてパフォーマンスが悪化するなら非正規化も検討
+3. **外部キー制約で整合性を保証する**
+4. **インデックスは「検索条件になるカラム」に張る**
+
+---
+
+## 完全なスキーマ定義（SQL）
+
+### users テーブル
+
+```sql
+CREATE TABLE users (
+  id         TEXT    PRIMARY KEY,               -- UUID (例: 'usr_01HXYZ...')
+  name       TEXT    NOT NULL,                  -- 表示名
+  email      TEXT    UNIQUE NOT NULL,           -- ログイン用メールアドレス
+  role       TEXT    NOT NULL DEFAULT 'general' -- 'general' | 'admin'
+               CHECK (role IN ('general', 'admin')),
+  created_at INTEGER NOT NULL DEFAULT (unixepoch())  -- Unix タイムスタンプ（秒）
+);
+```
+
+**設計上の決定**:
+- `id` に UUID（Text型）を使用: 連番だと総件数が推測されるためセキュリティ上好ましくない
+- `role` を CHECK 制約で列挙: 想定外の値を弾く
+- `email` を UNIQUE: 同じメールで複数アカウントを防ぐ
+
+---
+
+### quizzes テーブル
+
+```sql
+CREATE TABLE quizzes (
+  id              TEXT    PRIMARY KEY,           -- 例: 'qz_01HXYZ...'
+  question_word   TEXT    NOT NULL,              -- 問題文（例: 'とら'）
+  question_vowels TEXT    NOT NULL,              -- 問題の母音（例: 'おあ'）
+  image_key       TEXT    NOT NULL,              -- 画像ファイル名のキー（例: 'tora'）
+  explanation     TEXT    NOT NULL,              -- 解説文
+  created_by      TEXT    NOT NULL
+                    REFERENCES users(id)
+                    ON DELETE RESTRICT,          -- ユーザー削除を制限
+  created_at      INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- 投稿者でフィルタするクエリを高速化
+CREATE INDEX idx_quizzes_created_by ON quizzes(created_by);
+
+-- 新着順取得を高速化
+CREATE INDEX idx_quizzes_created_at ON quizzes(created_at DESC);
+```
+
+**設計上の決定**:
+- `question_vowels` は `quizzes` に直接持つ: 問題判定に常に必要なため JOIN 不要にする（意図的な冗長性）
+- `ON DELETE RESTRICT`: ユーザーが削除されてもクイズは残す（ユーザー削除時はまずクイズを別ユーザーに移管する運用を想定）
+
+---
+
+### choices テーブル
+
+```sql
+CREATE TABLE choices (
+  id          TEXT    PRIMARY KEY,              -- 例: 'ch_01HXYZ...'
+  quiz_id     TEXT    NOT NULL
+                REFERENCES quizzes(id)
+                ON DELETE CASCADE,             -- クイズ削除時に選択肢も一括削除
+  text        TEXT    NOT NULL,                -- 選択肢テキスト（例: 'おか'）
+  vowels      TEXT    NOT NULL,                -- 選択肢の母音（例: 'おあ'）
+  is_correct  INTEGER NOT NULL DEFAULT 0
+                CHECK (is_correct IN (0, 1)), -- 0: 不正解, 1: 正解
+  order_index INTEGER NOT NULL DEFAULT 0      -- 表示順（0始まり）
+);
+
+-- クイズの選択肢取得（最頻出クエリ）を高速化
+CREATE INDEX idx_choices_quiz_id ON choices(quiz_id);
+```
+
+---
+
+## テーブル間の依存関係
+
+```
+users
+  └── quizzes (created_by → users.id)
+        └── choices (quiz_id → quizzes.id)
+```
+
+削除の安全な順序: `choices` → `quizzes` → `users`
+
+---
+
+## 意図的な冗長性について
+
+### `question_vowels` をクイズテーブルに持つ理由
+
+正答判定フローを思い出す:
+
+```
+1. GET /api/quiz/next   → quizzes を取得（question_word だけ返せばよい）
+2. POST /api/quiz/:id/submit → 正誤判定のために question_vowels が必要
+```
+
+`question_vowels` をクイズテーブルに持たない場合、判定のたびにどこかから母音を計算/取得する必要がある。
+この値はクイズ作成時に確定し、変更されない（「とら」の母音は常に「おあ」）ため、
+**計算済みの値をキャッシュ的に保持する** のは合理的な設計。
+
+---
+
+## 冗長性を排除した箇所
+
+| 排除した冗長性                          | 理由                                       |
+|-----------------------------------------|--------------------------------------------|
+| クイズ行に投稿者名を直接持たない        | ユーザー名変更時に全クイズ行の更新が必要になるため |
+| 選択肢をカラムで並べない                | 選択肢数変更時にスキーマ変更が必要になるため |
+
+---
+
+## カラム型の選択指針（Turso / libSQL）
+
+Turso は SQLite ベースなので型が少ない:
+
+| 用途               | 使う型    | 理由                                      |
+|--------------------|-----------|-------------------------------------------|
+| ID（UUID）         | `TEXT`    | UUID は文字列                             |
+| 文字列             | `TEXT`    |                                           |
+| フラグ（true/false）| `INTEGER` | SQLite に BOOLEAN がない。0 or 1 で表現  |
+| 日時               | `INTEGER` | Unix タイムスタンプ（秒）が扱いやすい     |
+| 小数               | `REAL`    | スコアの割合など                          |
+
+---
+
+## スキーマ全体の俯瞰
+
+```
+┌─────────────┐         ┌──────────────────────────┐
+│   users     │         │        quizzes           │
+├─────────────┤         ├──────────────────────────┤
+│ id (PK)     │◄────────│ id (PK)                  │
+│ name        │  1 : N  │ created_by (FK)          │
+│ email       │         │ question_word            │
+│ role        │         │ question_vowels  ← 冗長 ✅│
+│ created_at  │         │ image_key                │
+└─────────────┘         │ explanation              │
+                        │ created_at               │
+                        └──────────┬───────────────┘
+                                   │ 1 : N
+                        ┌──────────▼───────────────┐
+                        │        choices           │
+                        ├──────────────────────────┤
+                        │ id (PK)                  │
+                        │ quiz_id (FK)             │
+                        │ text                     │
+                        │ vowels                   │
+                        │ is_correct               │
+                        │ order_index              │
+                        └──────────────────────────┘
+```
+
+---
+
+次: [04-sql-tuning.md — SQLチューニング](./04-sql-tuning.md)

--- a/docs/db/04-sql-tuning.md
+++ b/docs/db/04-sql-tuning.md
@@ -1,0 +1,174 @@
+# SQLチューニング
+
+パフォーマンスに影響する設計上の判断と、クエリ最適化の考え方を解説する。
+
+---
+
+## このアプリの主要クエリ
+
+まず「どんなクエリが頻繁に発行されるか」を把握する。
+
+| クエリ                                 | 頻度 |
+|----------------------------------------|------|
+| ランダムにクイズ1件取得                | 高   |
+| クイズの選択肢を一括取得               | 高   |
+| 特定クイズの正誤判定用データ取得       | 高   |
+| 管理者がクイズを投稿                   | 低   |
+| ユーザーのクイズ一覧取得               | 低   |
+
+---
+
+## インデックスの設計
+
+### 基本原則
+
+インデックスは「WHERE句、JOIN条件、ORDER BY で使われるカラム」に張る。
+ただし書き込みのたびにインデックスも更新されるため、**不要なインデックスは張らない**。
+
+### このアプリで必要なインデックス
+
+```sql
+-- choices の最頻出クエリ: WHERE quiz_id = ?
+-- → quiz_id にインデックスが必須
+CREATE INDEX idx_choices_quiz_id ON choices(quiz_id);
+
+-- quizzes の作成者別絞り込み: WHERE created_by = ?
+-- → created_by にインデックスが有効
+CREATE INDEX idx_quizzes_created_by ON quizzes(created_by);
+
+-- 新着順ページング: ORDER BY created_at DESC
+-- → 降順インデックスが有効
+CREATE INDEX idx_quizzes_created_at ON quizzes(created_at DESC);
+```
+
+### インデックスの効果を確認する（EXPLAIN）
+
+```sql
+-- インデックスが使われているか確認
+EXPLAIN QUERY PLAN
+SELECT * FROM choices WHERE quiz_id = 'q1';
+
+-- 結果例（インデックスあり）:
+-- SEARCH choices USING INDEX idx_choices_quiz_id (quiz_id=?)
+
+-- 結果例（インデックスなし）:
+-- SCAN choices
+-- ↑ テーブル全件スキャンが走っている = 遅い
+```
+
+---
+
+## N+1問題（最重要）
+
+> N+1問題の詳細と Drizzle ORM での解決策は [05-drizzle-orm.md](./05-drizzle-orm.md) を参照。
+
+ここでは SQL レベルで理解する。
+
+### 悪い例: N+1クエリ
+
+```
+1回目のクエリ: quizzes を全件取得（N件取得とする）
+  SELECT * FROM quizzes;               -- 1回
+
+2〜N+1回目: 各クイズの選択肢を個別取得
+  SELECT * FROM choices WHERE quiz_id = 'q1';  -- 1回
+  SELECT * FROM choices WHERE quiz_id = 'q2';  -- 1回
+  SELECT * FROM choices WHERE quiz_id = 'q3';  -- 1回
+  ...（N件のクイズがあれば N 回のクエリ）
+
+合計: 1 + N 回のクエリ
+```
+
+クイズが100件あれば101回のクエリが発行される。
+
+### 良い例: JOINで1回にまとめる
+
+```sql
+-- クイズと選択肢を一度に取得
+SELECT
+  q.id            AS quiz_id,
+  q.question_word,
+  q.question_vowels,
+  q.image_key,
+  q.explanation,
+  c.id            AS choice_id,
+  c.text          AS choice_text,
+  c.vowels        AS choice_vowels,
+  c.is_correct,
+  c.order_index
+FROM quizzes q
+LEFT JOIN choices c ON c.quiz_id = q.id
+ORDER BY q.created_at DESC, c.order_index;
+```
+
+合計: **1回**のクエリで全データ取得。
+
+---
+
+## ランダムクイズ取得の実装
+
+```sql
+-- SQLite / libSQL でのランダム1件取得
+SELECT * FROM quizzes
+ORDER BY RANDOM()
+LIMIT 1;
+```
+
+> `ORDER BY RANDOM()` は全件スキャンが必要なため大量データには不向き。
+> 件数が増えたら `OFFSET (RANDOM() % total_count)` 方式か、アプリ側でランダム選択を検討。
+
+---
+
+## 複合インデックス
+
+複数カラムを組み合わせた検索に使う。
+
+```sql
+-- 「特定ユーザーの最新クイズ」を取得するクエリ
+SELECT * FROM quizzes
+WHERE created_by = 'user-1'
+ORDER BY created_at DESC
+LIMIT 10;
+
+-- 複合インデックスで高速化
+CREATE INDEX idx_quizzes_user_time
+ON quizzes(created_by, created_at DESC);
+--           ↑ WHERE      ↑ ORDER BY
+```
+
+**複合インデックスのルール**: 左から順に使われる（「created_by だけで検索」も有効だが「created_at だけで検索」にはこのインデックスは使われない）。
+
+---
+
+## トランザクションによる整合性
+
+クイズと選択肢を同時に追加するとき、どちらかが失敗した場合に中途半端な状態にならないようにする。
+
+```sql
+BEGIN;
+  INSERT INTO quizzes (id, question_word, question_vowels, image_key, explanation, created_by)
+  VALUES ('q6', 'やま', 'ああ', 'yama', '「やま」の母音は「あああ」...', 'user-1');
+
+  INSERT INTO choices (id, quiz_id, text, vowels, is_correct, order_index) VALUES
+    ('q6-c1', 'q6', 'かな', 'あああ', 1, 0),
+    ('q6-c2', 'q6', 'さく', 'あう', 0, 1),
+    ('q6-c3', 'q6', 'ひと', 'いお', 0, 2),
+    ('q6-c4', 'q6', 'うえ', 'うえ', 0, 3);
+COMMIT;
+-- どちらかが失敗すれば ROLLBACK されてどちらも保存されない
+```
+
+---
+
+## パフォーマンス観点のまとめ
+
+| 対策                         | 効果                                               |
+|------------------------------|----------------------------------------------------|
+| `choices.quiz_id` インデックス | 選択肢取得クエリが O(N) → O(log N) 相当に改善      |
+| JOIN で1回クエリ              | N+1 問題を回避                                     |
+| トランザクション              | データ整合性の保証（パフォーマンスより正確性）      |
+| 適切な LIMIT                 | 大量データの誤取得を防ぐ                           |
+
+---
+
+次: [05-drizzle-orm.md — Drizzle ORM実装](./05-drizzle-orm.md)

--- a/docs/db/05-drizzle-orm.md
+++ b/docs/db/05-drizzle-orm.md
@@ -1,0 +1,508 @@
+# Drizzle ORM 実装解説
+
+Drizzle ORM を使ったスキーマ定義・クエリ実装を、1行ずつ解説する。
+
+---
+
+## Drizzle ORM とは
+
+- TypeScript ファーストの ORM（Object Relational Mapper）
+- SQL に近い書き方ができる（「SQL のように書ける TypeScript」）
+- 型安全: スキーマから型が自動生成される
+- Turso (libSQL / SQLite) に公式対応
+
+---
+
+## セットアップ
+
+```bash
+# パッケージのインストール
+pnpm add drizzle-orm @libsql/client
+pnpm add -D drizzle-kit
+```
+
+---
+
+## ① スキーマ定義
+
+`src/features/quiz/infrastructure/db/schema.ts`
+
+```typescript
+// drizzle-orm/libsql から SQLite 用のカラム定義ヘルパーをインポート
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+// ───────────────────────────────────────────────
+// users テーブル
+// ───────────────────────────────────────────────
+
+export const users = sqliteTable("users", {
+  // text("id") → TEXT 型の "id" カラムを定義
+  // .primaryKey() → このカラムが主キー
+  id: text("id").primaryKey(),
+
+  // .notNull() → NULL を禁止（必須項目）
+  name: text("name").notNull(),
+
+  // .unique() → 重複を禁止
+  email: text("email").unique().notNull(),
+
+  // .default("general") → INSERT 時に省略したら "general" が入る
+  role: text("role", { enum: ["general", "admin"] })
+    .notNull()
+    .default("general"),
+  //   ↑ { enum: [...] } で TypeScript 側の型も "general" | "admin" に絞れる
+
+  // sql`(unixepoch())` → SQL の関数を直接呼ぶ（現在時刻の Unix 秒）
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  //             ↑ $defaultFn → TypeScript 側でデフォルト値を生成する関数
+});
+
+// ───────────────────────────────────────────────
+// quizzes テーブル
+// ───────────────────────────────────────────────
+
+export const quizzes = sqliteTable("quizzes", {
+  id: text("id").primaryKey(),
+  questionWord: text("question_word").notNull(),
+  questionVowels: text("question_vowels").notNull(),
+  imageKey: text("image_key").notNull(),
+  explanation: text("explanation").notNull(),
+
+  // references(() => users.id) → users.id への外部キー
+  // () => で遅延評価することで循環参照エラーを防ぐ
+  createdBy: text("created_by")
+    .notNull()
+    .references(() => users.id),
+
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+// ───────────────────────────────────────────────
+// choices テーブル
+// ───────────────────────────────────────────────
+
+export const choices = sqliteTable("choices", {
+  id: text("id").primaryKey(),
+
+  // ON DELETE CASCADE: クイズ削除時に選択肢も自動削除
+  quizId: text("quiz_id")
+    .notNull()
+    .references(() => quizzes.id, { onDelete: "cascade" }),
+  //                               ↑ onDelete オプションで CASCADE を指定
+
+  text: text("text").notNull(),
+  vowels: text("vowels").notNull(),
+
+  // integer("is_correct", { mode: "boolean" }) → 内部は 0/1 だが TypeScript では boolean に見える
+  isCorrect: integer("is_correct", { mode: "boolean" }).notNull().default(false),
+
+  orderIndex: integer("order_index").notNull().default(0),
+});
+
+// ───────────────────────────────────────────────
+// TypeScript 型を自動生成
+// ───────────────────────────────────────────────
+
+// テーブルから INSERT/SELECT 時の型を導出
+// typeof users.$inferSelect → SELECT 結果の型 { id: string; name: string; ... }
+// typeof users.$inferInsert → INSERT 用の型（nullable フィールドが optional になる）
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;
+export type Quiz = typeof quizzes.$inferSelect;
+export type NewQuiz = typeof quizzes.$inferInsert;
+export type Choice = typeof choices.$inferSelect;
+export type NewChoice = typeof choices.$inferInsert;
+```
+
+---
+
+## ② DB接続
+
+`src/features/quiz/infrastructure/db/client.ts`
+
+```typescript
+// createClient → Turso (libSQL) への接続を作る
+import { createClient } from "@libsql/client";
+
+// drizzle → Drizzle ORM のメインエントリ（libSQL 用アダプター）
+import { drizzle } from "drizzle-orm/libsql";
+
+// スキーマをインポート（Drizzle がテーブル定義を認識するために必要）
+import * as schema from "./schema";
+
+// libSQL クライアントを作成
+// url と authToken は環境変数から読む（Cloudflare Pages の場合は env.TURSO_URL）
+const client = createClient({
+  url: process.env.TURSO_DATABASE_URL!,
+  // !  → TypeScript に「undefined にはならない」と伝えるキャスト（非 null アサーション）
+  authToken: process.env.TURSO_AUTH_TOKEN,
+  // authToken はローカル開発では不要（省略可）
+});
+
+// Drizzle インスタンスを作成してエクスポート
+// { schema } を渡すことで db.query.quizzes.findMany() のような Relational Query が使えるようになる
+export const db = drizzle(client, { schema });
+```
+
+---
+
+## ③ 基本的なクエリ
+
+### クイズ1件をランダムに取得
+
+```typescript
+import { db } from "../db/client";
+import { quizzes } from "../db/schema";
+import { sql } from "drizzle-orm";
+// sql → 生 SQL を TypeScript の中に埋め込むためのタグ付きテンプレートリテラル
+
+async function getRandomQuiz() {
+  const result = await db
+    .select()
+    // .select() → SELECT * に相当。引数に { id: quizzes.id } のように渡すと SELECT id だけになる
+    .from(quizzes)
+    // .from(quizzes) → FROM quizzes に相当
+    .orderBy(sql`RANDOM()`)
+    // .orderBy(sql`RANDOM()`) → ORDER BY RANDOM() に相当（SQLite でのランダム順）
+    .limit(1);
+    // .limit(1) → LIMIT 1 に相当
+
+  // result は Quiz[] 型（配列）なので最初の要素を取得
+  return result[0] ?? null;
+}
+```
+
+---
+
+## ④ N+1問題とその解決
+
+### 問題: N+1クエリになってしまうコード
+
+```typescript
+// ❌ 悪い例: クイズごとに選択肢クエリを発行してしまう
+async function getAllQuizzesWithChoicesBad() {
+  // クエリ 1回目: 全クイズ取得
+  const allQuizzes = await db.select().from(quizzes);
+  // ↑ SELECT * FROM quizzes → N件取得
+
+  // ループの中でクエリを発行 → N回のクエリ
+  const result = await Promise.all(
+    allQuizzes.map(async (quiz) => {
+      // クエリ 2〜N+1回目: 各クイズの選択肢を取得
+      const quizChoices = await db
+        .select()
+        .from(choices)
+        .where(eq(choices.quizId, quiz.id));
+      //       ↑ SELECT * FROM choices WHERE quiz_id = ?
+      //       クイズの数だけこのクエリが走る = N+1問題
+
+      return { ...quiz, choices: quizChoices };
+    })
+  );
+  return result;
+}
+// クイズが 100 件あれば → 1 + 100 = 101 回のクエリ 🔥
+```
+
+---
+
+### 解決策①: JOIN を使って1クエリにまとめる
+
+```typescript
+import { db } from "../db/client";
+import { quizzes, choices } from "../db/schema";
+import { eq } from "drizzle-orm";
+// eq → Equal（等号）条件を作るヘルパー。eq(choices.quizId, quizzes.id) → choices.quiz_id = quizzes.id
+
+async function getAllQuizzesWithChoicesJoin() {
+  // LEFT JOIN で一度に取得
+  const rows = await db
+    .select({
+      // 取得するカラムを明示的に指定
+      // キー名は任意（TypeScript での変数名になる）
+      quizId: quizzes.id,
+      questionWord: quizzes.questionWord,
+      questionVowels: quizzes.questionVowels,
+      imageKey: quizzes.imageKey,
+      explanation: quizzes.explanation,
+      choiceId: choices.id,
+      choiceText: choices.text,
+      choiceVowels: choices.vowels,
+      choiceIsCorrect: choices.isCorrect,
+      choiceOrderIndex: choices.orderIndex,
+    })
+    .from(quizzes)
+    // .leftJoin(対象テーブル, JOIN条件)
+    // LEFT JOIN: クイズに選択肢がなくても クイズ行は返す（choices.* は null になる）
+    .leftJoin(choices, eq(choices.quizId, quizzes.id))
+    //                  ↑ ON choices.quiz_id = quizzes.id
+    .orderBy(quizzes.createdAt, choices.orderIndex);
+    // ORDER BY quizzes.created_at, choices.order_index
+
+  // JOIN結果はフラットな行の配列なので、グループ化が必要
+  // 例: q1 の行が4行（選択肢4つ分）× クイズ数 だけ返ってくる
+  return groupQuizRows(rows);
+}
+
+// フラットな行を「クイズ + 選択肢の配列」構造に変換するヘルパー
+function groupQuizRows(rows: typeof result) {
+  const map = new Map<string, { quiz: Quiz; choices: Choice[] }>();
+
+  for (const row of rows) {
+    if (!map.has(row.quizId)) {
+      // まだこのクイズIDが登場していなければエントリを作成
+      map.set(row.quizId, {
+        quiz: { id: row.quizId, questionWord: row.questionWord, ... },
+        choices: [],
+      });
+    }
+
+    if (row.choiceId !== null) {
+      // choiceId が null でなければ（LEFT JOIN で一致した場合）選択肢を追加
+      map.get(row.quizId)!.choices.push({
+        id: row.choiceId,
+        text: row.choiceText!,
+        ...
+      });
+    }
+  }
+
+  return [...map.values()];
+}
+// クエリ合計: 1回 ✅
+```
+
+---
+
+### 解決策②: Drizzle Relational Queries（推奨）
+
+Drizzle の「Relational Queries」は、JOIN と グループ化を自動でやってくれる高レベル API。
+
+**まずリレーションを定義する** (`schema.ts` に追記):
+
+```typescript
+import { relations } from "drizzle-orm";
+// relations → テーブル間のリレーション定義ヘルパー
+
+// quizzes のリレーション定義
+export const quizzesRelations = relations(quizzes, ({ many, one }) => ({
+  // many("choices") → quizzes は choices を「多」持つ
+  choices: many(choices),
+  // one(users, ...) → quizzes は users を「一」参照する
+  creator: one(users, {
+    fields: [quizzes.createdBy],
+    // fields → 自テーブル側の外部キーカラム
+    references: [users.id],
+    // references → 参照先テーブルの主キーカラム
+  }),
+}));
+
+// choices のリレーション定義
+export const choicesRelations = relations(choices, ({ one }) => ({
+  // one(quizzes, ...) → choices は quizzes を「一」参照する
+  quiz: one(quizzes, {
+    fields: [choices.quizId],
+    references: [quizzes.id],
+  }),
+}));
+
+// users のリレーション定義
+export const usersRelations = relations(users, ({ many }) => ({
+  // many(quizzes) → users は quizzes を「多」持つ
+  quizzes: many(quizzes),
+}));
+```
+
+**Relational Queries でのクエリ**:
+
+```typescript
+async function getAllQuizzesWithChoicesRelational() {
+  // db.query.quizzes → schema で定義した quizzes テーブルへのクエリビルダー
+  const result = await db.query.quizzes.findMany({
+    // with: 一緒に取得するリレーションを指定
+    with: {
+      // choices: true → choices を全件取得
+      choices: {
+        // orderBy で選択肢の表示順を指定
+        orderBy: (choices, { asc }) => [asc(choices.orderIndex)],
+      },
+      // creator: true → 投稿者情報も取得
+      creator: {
+        // columns で取得するカラムを制限（パスワード等を隠す用途にも使える）
+        columns: { id: true, name: true, role: true },
+      },
+    },
+    // orderBy で最新順に並べる
+    orderBy: (quizzes, { desc }) => [desc(quizzes.createdAt)],
+  });
+
+  // result の型:
+  // {
+  //   id: string;
+  //   questionWord: string;
+  //   ...
+  //   choices: { id: string; text: string; ... }[];  ← 自動的に配列になる
+  //   creator: { id: string; name: string; role: "general" | "admin" };
+  // }[]
+
+  return result;
+}
+// クエリ合計: 内部で最適化された 1〜2 回のクエリ ✅
+```
+
+---
+
+## ⑤ 特定クイズの取得（1件）
+
+```typescript
+import { eq } from "drizzle-orm";
+
+async function getQuizById(id: string) {
+  // findFirst → 1件だけ取得（配列ではなく単一オブジェクトを返す）
+  const quiz = await db.query.quizzes.findFirst({
+    // where → 絞り込み条件
+    // eq(quizzes.id, id) → WHERE quizzes.id = id に相当
+    where: eq(quizzes.id, id),
+    with: {
+      choices: {
+        orderBy: (choices, { asc }) => [asc(choices.orderIndex)],
+      },
+    },
+  });
+
+  // quiz は QuizWithChoices | undefined
+  // undefined の場合は 404 エラー処理をする
+  return quiz ?? null;
+}
+```
+
+---
+
+## ⑥ クイズ投稿（管理者のみ）
+
+```typescript
+import { db } from "../db/client";
+import { quizzes, choices } from "../db/schema";
+
+async function createQuiz(input: {
+  questionWord: string;
+  questionVowels: string;
+  imageKey: string;
+  explanation: string;
+  createdBy: string;
+  choices: Array<{
+    text: string;
+    vowels: string;
+    isCorrect: boolean;
+    orderIndex: number;
+  }>;
+}) {
+  // crypto.randomUUID() → ランダムな UUID を生成（例: 'qz_01abc...'）
+  const quizId = `qz_${crypto.randomUUID()}`;
+
+  // db.transaction() → BEGIN / COMMIT / ROLLBACK を自動管理
+  // tx（transaction）は db と同じインターフェースを持つ
+  await db.transaction(async (tx) => {
+    // クイズを INSERT
+    await tx.insert(quizzes).values({
+      id: quizId,
+      questionWord: input.questionWord,
+      questionVowels: input.questionVowels,
+      imageKey: input.imageKey,
+      explanation: input.explanation,
+      createdBy: input.createdBy,
+    });
+    // ↑ INSERT INTO quizzes (...) VALUES (...) に相当
+
+    // 選択肢を一括 INSERT
+    await tx.insert(choices).values(
+      input.choices.map((choice, index) => ({
+        id: `ch_${crypto.randomUUID()}`,
+        quizId: quizId,
+        text: choice.text,
+        vowels: choice.vowels,
+        isCorrect: choice.isCorrect,
+        orderIndex: choice.orderIndex ?? index,
+      }))
+    );
+    // ↑ INSERT INTO choices (...) VALUES (...), (...), (...), (...) に相当
+    // 配列を渡すと1回のクエリで複数行を INSERT できる
+  });
+  // ここまで到達すれば COMMIT、例外が投げられれば自動 ROLLBACK
+
+  return quizId;
+}
+```
+
+---
+
+## ⑦ 正誤判定用のデータ取得
+
+```typescript
+async function getQuizForJudge(quizId: string) {
+  // 正誤判定に必要なデータ（母音、正解フラグ）を取得
+  return await db.query.quizzes.findFirst({
+    where: eq(quizzes.id, quizId),
+    with: {
+      choices: {
+        // columns で不要なカラムを省略してデータ量を減らす
+        columns: {
+          id: true,
+          vowels: true,
+          isCorrect: true,
+        },
+        // ↑ text や orderIndex は判定に不要なので取得しない
+      },
+    },
+    columns: {
+      id: true,
+      questionVowels: true,
+      explanation: true,
+    },
+    // ↑ image_key や created_by 等は判定に不要
+  });
+}
+```
+
+---
+
+## ⑧ 外部キー制約の有効化（Turso 接続時）
+
+SQLite / libSQL はデフォルトで外部キー制約が無効。接続時に有効化が必要。
+
+```typescript
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { sql } from "drizzle-orm";
+import * as schema from "./schema";
+
+const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+export const db = drizzle(client, { schema });
+
+// 外部キー制約を有効化（接続後すぐに実行）
+// PRAGMA foreign_keys = ON → SQLite の外部キー制約を有効にする設定
+await db.run(sql`PRAGMA foreign_keys = ON`);
+```
+
+---
+
+## まとめ
+
+| やること               | Drizzle のコード                          |
+|------------------------|-------------------------------------------|
+| スキーマ定義           | `sqliteTable()` + カラム定義ヘルパー      |
+| 型の自動生成           | `$inferSelect` / `$inferInsert`           |
+| 全件取得               | `db.select().from(table)`                 |
+| 条件付き取得           | `.where(eq(table.col, value))`            |
+| リレーション付き取得   | `db.query.table.findMany({ with: {...} })` |
+| 挿入                   | `db.insert(table).values({...})`          |
+| トランザクション       | `db.transaction(async (tx) => {...})`     |
+| N+1の回避              | `with:` を使った Relational Query         |
+
+---
+
+前: [04-sql-tuning.md](./04-sql-tuning.md)


### PR DESCRIPTION
## 概要

Issue #61 に基づき、ラップ韻クイズのDB設計に関する解説ドキュメントを `docs/db/` に追加した。

## 追加ファイル

| ファイル | 内容 |
|----------|------|
| `docs/db/00-basics.md` | DB基礎用語（テーブル、PK、FK、インデックス、正規化、N+1問題 等） |
| `docs/db/01-table-design.md` | 非正規化 vs 正規化の比較（更新異常・挿入異常・削除異常の解説付き） |
| `docs/db/02-relationships.md` | 1対多・多対多のリレーションシップ解説とER図 |
| `docs/db/03-schema-design.md` | 正規化・冗長性を意識した最終スキーマ定義（SQL・設計根拠付き） |
| `docs/db/04-sql-tuning.md` | インデックス設計、N+1問題（SQL視点）、EXPLAIN QUERY PLAN |
| `docs/db/05-drizzle-orm.md` | Drizzle ORM実装コードを1行ずつ解説（スキーマ定義〜Relational Query） |

## カバーしている内容

- DB基礎用語の解説
- 正規化 vs 非正規化の比較（3テーブル構成 users / quizzes / choices）
- リレーションシップ（1対多、多対多、CASCADE、参照整合性）
- 正規化・冗長性を意識したスキーマ設計（意図的な冗長性の理由も説明）
- SQLチューニング視点（インデックス設計、EXPLAIN、ランダム取得）
- Drizzle ORM実装（N+1問題とその解決策、Relational Queries、トランザクション）

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)